### PR TITLE
feat: 試合結果入力の選手に助っ人を追加する (#10)

### DIFF
--- a/app/api/games/[id]/lineup/route.ts
+++ b/app/api/games/[id]/lineup/route.ts
@@ -8,6 +8,7 @@ interface LineupEntry {
   position?: string
   isSubstitute?: boolean
   enteredInning?: number
+  isHelper?: boolean
 }
 
 // 打順を保存（都度保存用）
@@ -51,6 +52,7 @@ export async function POST(
         position: entry.position || null,
         is_substitute: entry.isSubstitute || false,
         entered_inning: entry.enteredInning || null,
+        is_helper: entry.isHelper || false,
       }))
 
       const { error } = await supabase

--- a/app/api/games/[id]/route.ts
+++ b/app/api/games/[id]/route.ts
@@ -127,8 +127,9 @@ export async function PUT(
       position: string | null
       is_substitute: boolean
       entered_inning: number | null
+      is_helper: boolean
     }> = []
-    
+
     for (const slot of lineupSlots) {
       for (const entry of slot.entries) {
         lineupInserts.push({
@@ -139,6 +140,7 @@ export async function PUT(
           position: entry.position || null,
           is_substitute: entry.isSubstitute || false,
           entered_inning: entry.enteredInning || null,
+          is_helper: entry.isHelper || false,
         })
       }
     }

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -44,10 +44,11 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: resultsError.message }, { status: 500 })
   }
 
-  // 打順エントリーを取得
+  // 打順エントリーを取得（助っ人を除く）
   let lineupQuery = supabase
     .from("lineup_entries")
-    .select("player_id, player_name, game_id, batting_order")
+    .select("player_id, player_name, game_id, batting_order, is_helper")
+    .eq("is_helper", false)
   if (teamId && gameIds.length > 0) {
     lineupQuery = lineupQuery.in("game_id", gameIds)
   }

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -140,6 +140,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
               position: entry.position,
               isSubstitute: entry.is_substitute,
               enteredInning: entry.entered_inning,
+              isHelper: entry.is_helper,
             })
           }
           

--- a/components/player-select-dialog.tsx
+++ b/components/player-select-dialog.tsx
@@ -153,54 +153,41 @@ export function PlayerSelectDialog({
                 <label className="block text-xs font-semibold text-slate-500 mb-2">
                   選手名
                 </label>
-                {/* 助っ人ボタン */}
-                <button
-                  onClick={() => handleHelperSelect(index)}
-                  className={cn(
-                    "w-full h-10 rounded-xl font-bold text-sm mb-2 transition-all",
-                    entry.isHelper
-                      ? "bg-purple-500 text-white shadow-md"
-                      : "bg-white border border-slate-200 text-slate-600 hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700"
-                  )}
-                >
-                  助っ人
-                </button>
-                {/* 助っ人でない場合のみ通常の選手選択を表示 */}
-                {!entry.isHelper && (
-                  registeredPlayers.length > 0 ? (
-                    <div className="space-y-2">
-                      <select
-                        value={entry.playerId}
-                        onChange={(e) => handlePlayerSelect(index, e.target.value)}
+                {registeredPlayers.length > 0 ? (
+                  <div className="space-y-2">
+                    <select
+                      value={entry.isHelper ? "" : entry.playerId}
+                      onChange={(e) => handlePlayerSelect(index, e.target.value)}
+                      className={cn(
+                        "w-full h-12 px-4 text-base rounded-xl",
+                        "bg-white border border-slate-200",
+                        "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
+                      )}
+                    >
+                      <option value="">選手を選択...</option>
+                      {sortPlayersByNumber(registeredPlayers).map((player) => (
+                        <option key={player.id} value={player.id}>
+                          {player.number ? `${player.number} ` : ""}{player.name}
+                        </option>
+                      ))}
+                    </select>
+                    {/* または手入力（助っ人でなく、IDが未選択の場合） */}
+                    {!entry.isHelper && !entry.playerId && (
+                      <input
+                        type="text"
+                        value={entry.playerName}
+                        onChange={(e) => handleNameChange(index, e.target.value)}
+                        placeholder="または名前を直接入力"
                         className={cn(
-                          "w-full h-12 px-4 text-base rounded-xl",
+                          "w-full h-10 px-4 text-sm rounded-lg",
                           "bg-white border border-slate-200",
                           "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
                         )}
-                      >
-                        <option value="">選手を選択...</option>
-                        {sortPlayersByNumber(registeredPlayers).map((player) => (
-                          <option key={player.id} value={player.id}>
-                            {player.number ? `${player.number} ` : ""}{player.name}
-                          </option>
-                        ))}
-                      </select>
-                      {/* または手入力 */}
-                      {!entry.playerId && (
-                        <input
-                          type="text"
-                          value={entry.playerName}
-                          onChange={(e) => handleNameChange(index, e.target.value)}
-                          placeholder="または名前を直接入力"
-                          className={cn(
-                            "w-full h-10 px-4 text-sm rounded-lg",
-                            "bg-white border border-slate-200",
-                            "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
-                          )}
-                        />
-                      )}
-                    </div>
-                  ) : (
+                      />
+                    )}
+                  </div>
+                ) : (
+                  !entry.isHelper && (
                     <input
                       type="text"
                       value={entry.playerName}
@@ -214,6 +201,18 @@ export function PlayerSelectDialog({
                     />
                   )
                 )}
+                {/* 助っ人トグル（選手選択の下、控えめなデザイン） */}
+                <button
+                  onClick={() => entry.isHelper ? handlePlayerSelect(index, "") : handleHelperSelect(index)}
+                  className={cn(
+                    "mt-2 text-xs px-3 py-1.5 rounded-lg transition-all",
+                    entry.isHelper
+                      ? "bg-purple-50 text-purple-600 border border-purple-300 font-medium"
+                      : "text-slate-400 border border-dashed border-slate-300 hover:border-slate-400 hover:text-slate-500"
+                  )}
+                >
+                  {entry.isHelper ? "✓ 助っ人" : "助っ人として登録"}
+                </button>
               </div>
 
               {/* 守備位置 */}

--- a/components/player-select-dialog.tsx
+++ b/components/player-select-dialog.tsx
@@ -46,17 +46,32 @@ export function PlayerSelectDialog({
     setEntries((prev) => {
       const newEntries = [...prev]
       if (player) {
-        newEntries[index] = { 
-          ...newEntries[index], 
+        newEntries[index] = {
+          ...newEntries[index],
           playerId: player.id,
           playerName: player.name,
+          isHelper: false,
         }
       } else {
-        newEntries[index] = { 
-          ...newEntries[index], 
+        newEntries[index] = {
+          ...newEntries[index],
           playerId: "",
           playerName: "",
+          isHelper: false,
         }
+      }
+      return newEntries
+    })
+  }
+
+  const handleHelperSelect = (index: number) => {
+    setEntries((prev) => {
+      const newEntries = [...prev]
+      newEntries[index] = {
+        ...newEntries[index],
+        playerId: "",
+        playerName: "助っ人",
+        isHelper: true,
       }
       return newEntries
     })
@@ -65,10 +80,11 @@ export function PlayerSelectDialog({
   const handleNameChange = (index: number, name: string) => {
     setEntries((prev) => {
       const newEntries = [...prev]
-      newEntries[index] = { 
-        ...newEntries[index], 
+      newEntries[index] = {
+        ...newEntries[index],
         playerName: name,
-        playerId: "" // 手入力の場合はIDをクリア
+        playerId: "", // 手入力の場合はIDをクリア
+        isHelper: false,
       }
       return newEntries
     })
@@ -137,51 +153,66 @@ export function PlayerSelectDialog({
                 <label className="block text-xs font-semibold text-slate-500 mb-2">
                   選手名
                 </label>
-                {registeredPlayers.length > 0 ? (
-                  <div className="space-y-2">
-                    <select
-                      value={entry.playerId}
-                      onChange={(e) => handlePlayerSelect(index, e.target.value)}
-                      className={cn(
-                        "w-full h-12 px-4 text-base rounded-xl",
-                        "bg-white border border-slate-200",
-                        "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
-                      )}
-                    >
-                      <option value="">選手を選択...</option>
-                      {sortPlayersByNumber(registeredPlayers).map((player) => (
-                        <option key={player.id} value={player.id}>
-                          {player.number ? `${player.number} ` : ""}{player.name}
-                        </option>
-                      ))}
-                    </select>
-                    {/* または手入力 */}
-                    {!entry.playerId && (
-                      <input
-                        type="text"
-                        value={entry.playerName}
-                        onChange={(e) => handleNameChange(index, e.target.value)}
-                        placeholder="または名前を直接入力"
+                {/* 助っ人ボタン */}
+                <button
+                  onClick={() => handleHelperSelect(index)}
+                  className={cn(
+                    "w-full h-10 rounded-xl font-bold text-sm mb-2 transition-all",
+                    entry.isHelper
+                      ? "bg-purple-500 text-white shadow-md"
+                      : "bg-white border border-slate-200 text-slate-600 hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700"
+                  )}
+                >
+                  助っ人
+                </button>
+                {/* 助っ人でない場合のみ通常の選手選択を表示 */}
+                {!entry.isHelper && (
+                  registeredPlayers.length > 0 ? (
+                    <div className="space-y-2">
+                      <select
+                        value={entry.playerId}
+                        onChange={(e) => handlePlayerSelect(index, e.target.value)}
                         className={cn(
-                          "w-full h-10 px-4 text-sm rounded-lg",
+                          "w-full h-12 px-4 text-base rounded-xl",
                           "bg-white border border-slate-200",
                           "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
                         )}
-                      />
-                    )}
-                  </div>
-                ) : (
-                  <input
-                    type="text"
-                    value={entry.playerName}
-                    onChange={(e) => handleNameChange(index, e.target.value)}
-                    placeholder="名前を入力"
-                    className={cn(
-                      "w-full h-12 px-4 text-lg rounded-lg",
-                      "bg-white border border-slate-200",
-                      "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
-                    )}
-                  />
+                      >
+                        <option value="">選手を選択...</option>
+                        {sortPlayersByNumber(registeredPlayers).map((player) => (
+                          <option key={player.id} value={player.id}>
+                            {player.number ? `${player.number} ` : ""}{player.name}
+                          </option>
+                        ))}
+                      </select>
+                      {/* または手入力 */}
+                      {!entry.playerId && (
+                        <input
+                          type="text"
+                          value={entry.playerName}
+                          onChange={(e) => handleNameChange(index, e.target.value)}
+                          placeholder="または名前を直接入力"
+                          className={cn(
+                            "w-full h-10 px-4 text-sm rounded-lg",
+                            "bg-white border border-slate-200",
+                            "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
+                          )}
+                        />
+                      )}
+                    </div>
+                  ) : (
+                    <input
+                      type="text"
+                      value={entry.playerName}
+                      onChange={(e) => handleNameChange(index, e.target.value)}
+                      placeholder="名前を入力"
+                      className={cn(
+                        "w-full h-12 px-4 text-lg rounded-lg",
+                        "bg-white border border-slate-200",
+                        "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
+                      )}
+                    />
+                  )
                 )}
               </div>
 

--- a/lib/batting-types.ts
+++ b/lib/batting-types.ts
@@ -92,6 +92,7 @@ export interface LineupEntry {
   position?: FieldPosition
   isSubstitute?: boolean  // 代打・途中出場
   enteredInning?: number  // 何回から出場したか
+  isHelper?: boolean      // 助っ人（個人成績に含めない）
 }
 
 // 打順のスロット（1試合で複数選手が入る可能性）

--- a/scripts/002_add_is_helper_to_lineup_entries.sql
+++ b/scripts/002_add_is_helper_to_lineup_entries.sql
@@ -1,0 +1,1 @@
+ALTER TABLE lineup_entries ADD COLUMN IF NOT EXISTS is_helper BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## 概要

issue #10 の対応。試合結果入力時に「助っ人」を選択できるようにする。

## 変更内容

- 選手選択ダイアログに「助っ人として登録」トグルボタンを追加（選手選択エリアの下に控えめなデザインで配置）
- 助っ人選択後も通常の選手に変更可能（ドロップダウンから選択すると自動的に助っ人が解除）
- `lineup_entries` テーブルに `is_helper` カラムを追加するマイグレーション追加
- 個人成績（`/stats`）から助っ人を除外

## 仕様

- 試合結果上では他選手と変わらず表示される
- 1試合に複数の助っ人を登録可能
- 個人成績には助っ人の成績は表示されない

## マイグレーション

`scripts/002_add_is_helper_to_lineup_entries.sql` をSupabaseで実行してください。

```sql
ALTER TABLE lineup_entries ADD COLUMN IF NOT EXISTS is_helper BOOLEAN NOT NULL DEFAULT false;
```

## Test plan

- [ ] 選手選択ダイアログで「助っ人として登録」ボタンが選手選択の下に表示されること
- [ ] 助っ人を選択後、ドロップダウンから別の選手を選択できること
- [ ] 助っ人ボタンを再度クリックすると解除されること
- [ ] 1試合に複数の打順で助っ人を登録できること
- [ ] 個人成績ページに助っ人が表示されないこと

https://claude.ai/code/session_0137dBkrFrUZxGCLhBkMZGme

---
_Generated by [Claude Code](https://claude.ai/code/session_0137dBkrFrUZxGCLhBkMZGme)_