### PR TITLE
feat: アプリ名を「やきゅスコ」に統一し定数化 (issue #14)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,14 +2,15 @@ import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
 import { AppHeader } from '@/components/app-header'
+import { APP_NAME } from '@/lib/constants'
 import './globals.css'
 
 const _geist = Geist({ subsets: ["latin"] });
 const _geistMono = Geist_Mono({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: '野球スコア',
-  description: '野球の試合結果・打撃成績・投手成績を記録するアプリ',
+  title: APP_NAME,
+  description: `${APP_NAME} - 野球の試合結果・打撃成績・投手成績を記録するアプリ`,
   generator: 'v0.app',
   icons: {
     icon: [

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { Users, BarChart3, Calendar, ChevronRight } from "lucide-react"
+import { APP_NAME } from "@/lib/constants"
 
 export default function LandingPage() {
   return (
@@ -7,7 +8,7 @@ export default function LandingPage() {
       {/* ヘッダー */}
       <header className="mx-auto max-w-6xl px-4 py-6">
         <nav className="flex items-center justify-between">
-          <h1 className="text-2xl font-bold text-white">野球スコア</h1>
+          <h1 className="text-2xl font-bold text-white">{APP_NAME}</h1>
           <div className="flex items-center gap-4">
             <Link
               href="/register"
@@ -104,7 +105,7 @@ export default function LandingPage() {
       {/* フッター */}
       <footer className="border-t border-slate-700 py-8">
         <div className="mx-auto max-w-6xl px-4 text-center text-sm text-slate-500">
-          <p>野球スコア - チームの記録を管理するアプリ</p>
+          <p>{APP_NAME} - チームの記録を管理するアプリ</p>
         </div>
       </footer>
     </main>

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -79,18 +79,18 @@ export function AppHeader() {
     <header className="sticky top-0 z-50 bg-white shadow-sm">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
         {/* チーム名/ロゴ */}
-        <div className="flex items-center gap-2">
-          <Link
-            href={`/${teamId}`}
-            className="flex items-center gap-2 text-xl font-bold text-blue-600 hover:text-blue-700 transition-colors"
-          >
-            <span className="text-2xl">&#9918;</span>
-            <span className="max-w-[150px] truncate sm:max-w-none">
+        <Link
+          href={`/${teamId}`}
+          className="flex items-center gap-2 text-xl font-bold text-blue-600 hover:text-blue-700 transition-colors"
+        >
+          <span className="text-2xl">&#9918;</span>
+          <span className="flex flex-col">
+            <span className="max-w-[150px] truncate sm:max-w-none leading-tight">
               {teamName || teamId}
             </span>
-          </Link>
-          <span className="text-xs text-slate-400 hidden sm:inline">| {APP_NAME}</span>
-        </div>
+            <span className="text-xs font-normal text-slate-400 leading-tight">{APP_NAME}</span>
+          </span>
+        </Link>
 
         {/* デスクトップナビ */}
         <nav className="hidden md:flex items-center gap-1">

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -5,6 +5,7 @@ import { usePathname, useParams, useRouter } from "next/navigation"
 import { Home, List, BarChart3, Users, Menu, X, LogIn, LogOut, Shield } from "lucide-react"
 import { useState, useEffect } from "react"
 import { cn } from "@/lib/utils"
+import { APP_NAME } from "@/lib/constants"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -78,15 +79,18 @@ export function AppHeader() {
     <header className="sticky top-0 z-50 bg-white shadow-sm">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
         {/* チーム名/ロゴ */}
-        <Link
-          href={`/${teamId}`}
-          className="flex items-center gap-2 text-xl font-bold text-blue-600 hover:text-blue-700 transition-colors"
-        >
-          <span className="text-2xl">&#9918;</span>
-          <span className="max-w-[150px] truncate sm:max-w-none">
-            {teamName || teamId}
-          </span>
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link
+            href={`/${teamId}`}
+            className="flex items-center gap-2 text-xl font-bold text-blue-600 hover:text-blue-700 transition-colors"
+          >
+            <span className="text-2xl">&#9918;</span>
+            <span className="max-w-[150px] truncate sm:max-w-none">
+              {teamName || teamId}
+            </span>
+          </Link>
+          <span className="text-xs text-slate-400 hidden sm:inline">| {APP_NAME}</span>
+        </div>
 
         {/* デスクトップナビ */}
         <nav className="hidden md:flex items-center gap-1">

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+export const APP_NAME = "やきゅスコ"


### PR DESCRIPTION
APP_NAME定数をlib/constants.tsで一元管理し、トップページ・メタデータ・チームヘッダーに反映。チーム画面ではチーム名右に目立たない形でアプリ名を表示。

https://claude.ai/code/session_01F5yNkEcZUzxmDF2h8r5nZ9