### PR TITLE
feat: 未登録チームIDへのアクセスを404に変更 (issue #6)

### DIFF
--- a/app/[teamId]/layout.tsx
+++ b/app/[teamId]/layout.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
+import { AppHeader } from "@/components/app-header"
 
 interface Props {
   children: React.ReactNode
@@ -20,5 +21,10 @@ export default async function TeamLayout({ children, params }: Props) {
     notFound()
   }
 
-  return <>{children}</>
+  return (
+    <>
+      <AppHeader />
+      {children}
+    </>
+  )
 }

--- a/app/[teamId]/layout.tsx
+++ b/app/[teamId]/layout.tsx
@@ -1,0 +1,24 @@
+import { notFound } from "next/navigation"
+import { createClient } from "@/lib/supabase/server"
+
+interface Props {
+  children: React.ReactNode
+  params: Promise<{ teamId: string }>
+}
+
+export default async function TeamLayout({ children, params }: Props) {
+  const { teamId } = await params
+  const supabase = await createClient()
+
+  const { data } = await supabase
+    .from("teams")
+    .select("id")
+    .eq("id", teamId)
+    .single()
+
+  if (!data) {
+    notFound()
+  }
+
+  return <>{children}</>
+}

--- a/app/[teamId]/not-found.tsx
+++ b/app/[teamId]/not-found.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link"
+import { AlertCircle } from "lucide-react"
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-100 to-slate-200 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl shadow-xl p-8 max-w-md w-full text-center">
+        <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+          <AlertCircle className="w-8 h-8 text-red-500" />
+        </div>
+        <h1 className="text-2xl font-bold text-slate-800 mb-2">404</h1>
+        <p className="text-slate-600 mb-6">
+          チームが見つかりません。
+        </p>
+        <Link
+          href="/"
+          className="inline-block px-6 py-3 bg-slate-800 text-white font-semibold rounded-lg hover:bg-slate-700 transition-colors"
+        >
+          トップページへ
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
-import { AppHeader } from '@/components/app-header'
 import { APP_NAME } from '@/lib/constants'
 import './globals.css'
 
@@ -39,7 +38,6 @@ export default function RootLayout({
   return (
     <html lang="ja" className="bg-background">
       <body className="font-sans antialiased">
-        <AppHeader />
         {children}
         {process.env.NODE_ENV === 'production' && <Analytics />}
       </body>

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -25,9 +25,6 @@ export function AppHeader() {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
   const [loggedInTeamId, setLoggedInTeamId] = useState<string | null>(null)
 
-  // チームが指定されていない場合（ランディングページ等）はヘッダーを表示しない
-  const isTeamPage = teamId && !pathname.startsWith("/register")
-
   // チーム名を取得
   useEffect(() => {
     if (teamId) {
@@ -60,8 +57,6 @@ export function AppHeader() {
     setLoggedInTeamId(null)
     router.refresh()
   }
-
-  if (!isTeamPage) return null
 
   // このチームの管理者としてログインしているか
   const isTeamAdmin = isLoggedIn && loggedInTeamId === teamId


### PR DESCRIPTION
[teamId]/layout.tsx をサーバーコンポーネントとして追加し、
Supabase でチームの存在を確認。未登録IDの場合は notFound() を呼び出す。
対応する not-found.tsx も追加。

https://claude.ai/code/session_01YJTGHf9nUWEu7X5gQKyh8Y