### PR TITLE
Sort players by number in list and after mutations

### DIFF
--- a/app/[teamId]/players/page.tsx
+++ b/app/[teamId]/players/page.tsx
@@ -65,7 +65,7 @@ export default function PlayersPage() {
       }
 
       const player = await response.json()
-      setPlayers((prev) => [...prev, player])
+      setPlayers((prev) => sortPlayersByNumber([...prev, player]))
       setNewName("")
       setNewNumber("")
       setIsAdding(false)
@@ -103,7 +103,7 @@ export default function PlayersPage() {
       }
 
       const updated = await response.json()
-      setPlayers((prev) => prev.map((p) => (p.id === editingId ? updated : p)))
+      setPlayers((prev) => sortPlayersByNumber(prev.map((p) => (p.id === editingId ? updated : p))))
       setEditingId(null)
     } catch (error) {
       console.error(error)

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -11,6 +11,7 @@ export async function GET(request: Request) {
   let query = supabase
     .from("players")
     .select("*")
+    .order("number", { ascending: true, nullsFirst: false })
     .order("name")
 
   if (teamId) {


### PR DESCRIPTION
## Summary
This PR ensures players are consistently sorted by their jersey number throughout the application, both when fetching the initial list and after adding or updating players.

## Key Changes
- **API endpoint**: Added `.order("number", { ascending: true, nullsFirst: false })` to the GET players query to sort results by jersey number in ascending order, with null values placed last
- **Add player**: Wrapped the state update in `sortPlayersByNumber()` to maintain sort order when a new player is added
- **Update player**: Wrapped the state update in `sortPlayersByNumber()` to maintain sort order when a player's information is updated

## Implementation Details
The changes ensure that the player list remains sorted by jersey number at all times:
1. The API now returns players pre-sorted by number (primary) and name (secondary)
2. Client-side mutations (add/update) also apply the same sorting logic to prevent unsorted states during optimistic updates
3. This provides a consistent user experience regardless of how the list is modified

https://claude.ai/code/session_01TXHnkNwzXrDzbSLty3VLZV