### PR TITLE
Add location field and refactor memo display in game editor

### DIFF
--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -225,6 +225,14 @@ export default function GameDetailPage() {
           </div>
         </div>
 
+        {/* メモ */}
+        {game.memo && (
+          <div className="rounded-2xl bg-white p-4 shadow-lg">
+            <h2 className="mb-2 text-sm font-bold text-slate-600">メモ</h2>
+            <p className="whitespace-pre-wrap text-sm text-slate-700">{game.memo}</p>
+          </div>
+        )}
+
         {/* スコアボード */}
         <div className="rounded-2xl bg-white p-4 shadow-lg">
           <h2 className="mb-3 text-sm font-bold text-slate-600">スコアボード</h2>
@@ -387,13 +395,6 @@ export default function GameDetailPage() {
           )}
         </div>
 
-        {/* メモ */}
-        {game.memo && (
-          <div className="rounded-2xl bg-white p-4 shadow-lg">
-            <h2 className="mb-2 text-sm font-bold text-slate-600">メモ</h2>
-            <p className="whitespace-pre-wrap text-sm text-slate-700">{game.memo}</p>
-          </div>
-        )}
       </div>
     </main>
   )

--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -223,15 +223,10 @@ export default function GameDetailPage() {
               </span>
             </div>
           </div>
+          {game.memo && (
+            <p className="mt-3 whitespace-pre-wrap text-sm text-slate-600 border-t border-slate-100 pt-3">{game.memo}</p>
+          )}
         </div>
-
-        {/* メモ */}
-        {game.memo && (
-          <div className="rounded-2xl bg-white p-4 shadow-lg">
-            <h2 className="mb-2 text-sm font-bold text-slate-600">メモ</h2>
-            <p className="whitespace-pre-wrap text-sm text-slate-700">{game.memo}</p>
-          </div>
-        )}
 
         {/* スコアボード */}
         <div className="rounded-2xl bg-white p-4 shadow-lg">

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -36,6 +36,8 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
   // 試合情報
   const [gameDate, setGameDate] = useState("")
   const [opponent, setOpponent] = useState("")
+  const [location, setLocation] = useState("")
+  const [memo, setMemo] = useState("")
   const [isFirstBatting, setIsFirstBatting] = useState(true)
   const [totalInnings, setTotalInnings] = useState(9)
 
@@ -105,6 +107,8 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
         if (gameData.game) {
           setGameDate(gameData.game.date || "")
           setOpponent(gameData.game.opponent || "")
+          setLocation(gameData.game.location || "")
+          setMemo(gameData.game.memo || "")
           setIsFirstBatting(gameData.game.is_first_batting ?? true)
           setTotalInnings(gameData.game.total_innings ?? 9)
         }
@@ -350,11 +354,15 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
   }
 
   // 試合情報を都度保存
-  const handleGameInfoChange = useCallback((field: "date" | "opponent" | "isFirstBatting" | "totalInnings", value: string | boolean | number) => {
+  const handleGameInfoChange = useCallback((field: "date" | "opponent" | "location" | "memo" | "isFirstBatting" | "totalInnings", value: string | boolean | number) => {
     if (field === "date") {
       setGameDate(value as string)
     } else if (field === "opponent") {
       setOpponent(value as string)
+    } else if (field === "location") {
+      setLocation(value as string)
+    } else if (field === "memo") {
+      setMemo(value as string)
     } else if (field === "isFirstBatting") {
       setIsFirstBatting(value as boolean)
     } else if (field === "totalInnings") {
@@ -509,6 +517,26 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
                 className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
               />
             </div>
+            <div className="flex flex-1 items-center gap-2">
+              <label className="text-sm text-slate-600 whitespace-nowrap">球場</label>
+              <input
+                type="text"
+                value={location}
+                onChange={(e) => handleGameInfoChange("location", e.target.value)}
+                placeholder="球場名を入力"
+                className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+          <div className="mt-4">
+            <label className="mb-1 block text-sm text-slate-600">メモ</label>
+            <textarea
+              value={memo}
+              onChange={(e) => handleGameInfoChange("memo", e.target.value)}
+              placeholder="試合のメモを入力"
+              rows={3}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 resize-none"
+            />
           </div>
         </div>
         


### PR DESCRIPTION
## Summary
This PR adds a new "location" (球場) field to the game editor and refactors the memo display in the game detail page for better UI organization.

## Key Changes
- **Added location field**: New input field in the game editor to capture the stadium/venue name where the game is played
- **Added memo field to editor**: Converted memo from display-only to an editable textarea in the game editor component
- **Refactored memo display**: Moved memo display from a separate card section to inline within the game info section on the detail page for a more compact layout
- **Updated state management**: Added `location` and `memo` state variables with proper initialization from game data and change handlers

## Implementation Details
- The location field is displayed inline with opponent information in a flex layout
- The memo textarea is a full-width field with 3 rows and disabled resize
- Both new fields are integrated into the existing `handleGameInfoChange` callback with proper type handling
- The memo display on the detail page now appears directly below the game info section with appropriate styling (whitespace preservation, border separator)
- All styling follows the existing design system with consistent border, padding, and focus states

https://claude.ai/code/session_017Hyz3yTQSYJ7JQAq3A9wed