### PR TITLE
Resolve player names via JOIN instead of denormalized data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ next.user-config.*
 node_modules
 .next/
 .DS_Store
+tsconfig.tsbuildinfo

--- a/app/api/games/[id]/route.ts
+++ b/app/api/games/[id]/route.ts
@@ -27,13 +27,20 @@ export async function GET(
     .eq("game_id", id)
     .order("inning")
 
-  // 打順を取得
-  const { data: lineupEntries } = await supabase
+  // 打順を取得（選手名をJOINで解決）
+  const { data: rawLineupEntries } = await supabase
     .from("lineup_entries")
-    .select("*")
+    .select("*, players(name)")
     .eq("game_id", id)
     .order("batting_order")
     .order("entered_inning", { nullsFirst: true })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const lineupEntries = (rawLineupEntries || []).map((entry: any) => ({
+    ...entry,
+    player_name: entry.players?.name || entry.player_name,
+    players: undefined,
+  }))
 
   // 打撃結果を取得
   const { data: battingResults } = await supabase
@@ -41,19 +48,26 @@ export async function GET(
     .select("*")
     .eq("game_id", id)
 
-  // 投手成績を取得
-  const { data: pitcherResults } = await supabase
+  // 投手成績を取得（選手名をJOINで解決）
+  const { data: rawPitcherResults } = await supabase
     .from("pitcher_results")
-    .select("*")
+    .select("*, players(name)")
     .eq("game_id", id)
     .order("order_index")
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pitcherResults = (rawPitcherResults || []).map((result: any) => ({
+    ...result,
+    player_name: result.players?.name || result.player_name,
+    players: undefined,
+  }))
 
   return NextResponse.json({
     game,
     inningScores: inningScores || [],
-    lineupEntries: lineupEntries || [],
+    lineupEntries,
     battingResults: battingResults || [],
-    pitcherResults: pitcherResults || [],
+    pitcherResults,
   })
 }
 

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -44,10 +44,10 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: resultsError.message }, { status: 500 })
   }
 
-  // 打順エントリーを取得（助っ人を除く）
+  // 打順エントリーを取得（助っ人を除く、選手名JOINで解決）
   let lineupQuery = supabase
     .from("lineup_entries")
-    .select("player_id, player_name, game_id, batting_order, is_helper")
+    .select("player_id, player_name, game_id, batting_order, is_helper, players(name)")
     .eq("is_helper", false)
   if (teamId && gameIds.length > 0) {
     lineupQuery = lineupQuery.in("game_id", gameIds)
@@ -58,13 +58,16 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: lineupError.message }, { status: 500 })
   }
 
-  // 打順エントリーから選手とゲームの紐付けを作成
+  // 打順エントリーから選手とゲームの紐付けを作成（削除済み選手はスキップ）
   const battingOrderMap = new Map<string, { playerId: string; playerName: string }>()
   for (const entry of lineupEntries || []) {
+    if (!entry.player_id) continue
     const key = `${entry.game_id}-${entry.batting_order}`
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const players = (entry as any).players as { name: string } | null
     battingOrderMap.set(key, {
-      playerId: entry.player_id || entry.player_name,
-      playerName: entry.player_name,
+      playerId: entry.player_id,
+      playerName: players?.name || entry.player_name,
     })
   }
 
@@ -125,8 +128,8 @@ export async function GET(request: Request) {
   // 打席数でソート
   battingStatsResponse.sort((a, b) => b.stats.plateAppearances - a.stats.plateAppearances)
 
-  // 投手成績を取得
-  let pitcherQuery = supabase.from("pitcher_results").select("*")
+  // 投手成績を取得（選手名JOINで解決）
+  let pitcherQuery = supabase.from("pitcher_results").select("*, players(name)")
   if (teamId && gameIds.length > 0) {
     pitcherQuery = pitcherQuery.in("game_id", gameIds)
   }
@@ -136,7 +139,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: pitcherError.message }, { status: 500 })
   }
 
-  // 投手ごとにグループ化
+  // 投手ごとにグループ化（削除済み選手はスキップ）
   const pitcherResultsMap = new Map<string, {
     name: string
     results: Array<{
@@ -156,8 +159,11 @@ export async function GET(request: Request) {
   }>()
 
   for (const result of pitcherResults || []) {
-    const pitcherId = result.player_id || result.player_name
-    const pitcherName = result.player_name
+    if (!result.player_id) continue
+    const pitcherId = result.player_id
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pitcherPlayers = (result as any).players as { name: string } | null
+    const pitcherName = pitcherPlayers?.name || result.player_name
 
     if (!pitcherResultsMap.has(pitcherId)) {
       pitcherResultsMap.set(pitcherId, {


### PR DESCRIPTION
## Summary
This PR refactors player name resolution to fetch names directly from the `players` table via JOIN queries instead of relying on denormalized `player_name` fields. This improves data consistency and ensures player names are always up-to-date.

## Key Changes
- **Game API (`/api/games/[id]`)**: Updated `lineup_entries` and `pitcher_results` queries to JOIN with the `players` table and extract the `name` field, falling back to the denormalized `player_name` if the player record is missing
- **Stats API (`/api/stats`)**: 
  - Updated `lineup_entries` query to include `players(name)` JOIN
  - Updated `pitcher_results` query to include `players(name)` JOIN
  - Added null checks to skip entries/results with missing `player_id` (deleted players)
  - Changed `playerId` assignment to use `player_id` directly instead of falling back to `player_name`
  - Updated player name resolution to use joined player data with fallback to denormalized field
- **Build config**: Added `tsconfig.tsbuildinfo` to `.gitignore` to exclude TypeScript build cache

## Implementation Details
- All JOIN queries use the pattern `select("..., players(name)")` to fetch related player names
- Data transformation maps are applied to normalize the response structure, removing the nested `players` object
- Fallback logic preserves backward compatibility: if a player record is deleted, the denormalized `player_name` is used
- Added `@typescript-eslint/no-explicit-any` eslint-disable comments for type-safe data transformations

https://claude.ai/code/session_01P2QC27R9ZHydpR8xhWi71t