### PR TITLE
feat: faviconとヘッダーアイコンを新デザイン画像に設定 (#26)

### DIFF
--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import Link from "next/link"
+import Image from "next/image"
 import { usePathname, useParams, useRouter } from "next/navigation"
 import { Home, List, BarChart3, Users, Menu, X, LogIn, LogOut, Shield } from "lucide-react"
 import { useState, useEffect } from "react"
@@ -78,7 +79,7 @@ export function AppHeader() {
           href={`/${teamId}`}
           className="flex items-center gap-2 text-xl font-bold text-blue-600 hover:text-blue-700 transition-colors"
         >
-          <span className="text-2xl">&#9918;</span>
+          <Image src="/apple-icon.png" alt="やきゅすこ" width={36} height={36} className="rounded-lg" />
           <span className="flex flex-col">
             <span className="max-w-[150px] truncate sm:max-w-none leading-tight">
               {teamName || teamId}


### PR DESCRIPTION
## Summary

- 野球ダイヤモンド＋「や」文字のネイビー背景アイコン画像を favicon として設定
- ヘッダー左上の野球ボール絵文字をアプリアイコン画像に差し替え
- 不要なプレースホルダー画像5点と `icon.svg` を削除

## 変更内容

### favicon 画像の差し替え
- `public/icon-light-32x32.png` / `icon-dark-32x32.png` (32×32) — ライト/ダークモード用ブラウザアイコン
- `public/apple-icon.png` (180×180) — Apple タッチアイコン
- 元画像 (1024×1024) からクロップ・余白透過処理を施してリサイズ

### ヘッダーアイコンの差し替え
- `components/app-header.tsx` — `&#9918;` 絵文字 → `<Image src="/apple-icon.png" width={36} height={36} />`

### 削除ファイル
- `public/icon.svg`
- `public/placeholder-logo.png` / `.svg`
- `public/placeholder-user.jpg`
- `public/placeholder.jpg` / `.svg`

### `app/layout.tsx`
- `metadata.icons` から SVG エントリを削除
- `generator` を `'v0.app'` → `'next.js'` に修正

## Test plan

- [ ] ブラウザのタブに新しいアイコンが表示されること
- [ ] ライト/ダークモード切り替えで適切なアイコンが表示されること
- [ ] iOS Safari でホーム画面追加時に apple-icon が使われること
- [ ] チーム画面ヘッダー左上にアイコン画像が表示されること

https://claude.ai/code/session_01VHUmbUC8RwRvWQwPjQ8M1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHUmbUC8RwRvWQwPjQ8M1c)_