### PR TITLE
fix: 試合結果画面の投手成績テーブルの余白を除去

### DIFF
--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -350,7 +350,7 @@ export default function GameDetailPage() {
         <div className="rounded-2xl bg-white shadow-lg overflow-hidden">
           <h2 className="px-4 py-3 text-sm font-bold text-slate-600 border-b border-slate-200 bg-slate-50">投手成績</h2>
           {pitcherResults.length > 0 ? (
-            <div className="overflow-x-auto p-4">
+            <div className="overflow-x-auto">
               <table className="w-full text-center text-sm">
                 <thead>
                   <tr className="border-b bg-slate-50">


### PR DESCRIPTION
投手成績テーブルのラッパーから p-4 を削除し、打撃成績パネルと同じく
外枠にぴったりくっついたレイアウトに統一する。

Closes #30

https://claude.ai/code/session_018GeTczkuy8ZjyrpcwxT65a