### PR TITLE
試合結果編集画面のスコアボードと打撃成績のヘッダー色を統一

### DIFF
--- a/components/batting-grid.tsx
+++ b/components/batting-grid.tsx
@@ -64,14 +64,14 @@ export function BattingGrid({
       <div className="overflow-x-auto">
         <table className="w-full border-collapse" style={{ minWidth: `${Math.max(500, 136 + totalInnings * 48)}px` }}>
           <thead>
-            <tr className="bg-slate-800 text-white">
-              <th className="sticky left-0 z-20 bg-slate-800 w-10 min-w-[40px] px-2 py-3 text-center text-xs font-semibold border-r border-slate-700">
+            <tr className="bg-slate-50 text-slate-600">
+              <th className="sticky left-0 z-20 bg-slate-50 w-10 min-w-[40px] px-2 py-3 text-center text-xs font-semibold border-r border-slate-200">
                 打順
               </th>
-              <th className="sticky left-10 z-20 bg-slate-800 w-10 min-w-[40px] px-2 py-3 text-center text-xs font-semibold border-r border-slate-700">
+              <th className="sticky left-10 z-20 bg-slate-50 w-10 min-w-[40px] px-2 py-3 text-center text-xs font-semibold border-r border-slate-200">
                 守
               </th>
-              <th className="sticky left-20 z-20 bg-slate-800 w-24 min-w-[96px] px-2 py-3 text-center text-xs font-semibold border-r border-slate-700">
+              <th className="sticky left-20 z-20 bg-slate-50 w-24 min-w-[96px] px-2 py-3 text-center text-xs font-semibold border-r border-slate-200">
                 選手名
               </th>
               {innings.map((inning) => (

--- a/components/score-input.tsx
+++ b/components/score-input.tsx
@@ -147,8 +147,8 @@ export function ScoreInput({
       <div className="overflow-x-auto">
         <table className="w-full border-collapse" style={{ minWidth: `${Math.max(400, 80 + totalInnings * 40 + 56)}px` }}>
           <thead>
-            <tr className="bg-slate-800 text-white">
-              <th className="sticky left-0 z-10 bg-slate-800 w-20 min-w-[80px] px-3 py-2 text-left text-xs font-semibold"></th>
+            <tr className="bg-slate-50 text-slate-600">
+              <th className="sticky left-0 z-10 bg-slate-50 w-20 min-w-[80px] px-3 py-2 text-left text-xs font-semibold"></th>
               {innings.map((inning) => (
                 <th
                   key={inning}
@@ -157,7 +157,7 @@ export function ScoreInput({
                   {inning}
                 </th>
               ))}
-              <th className="sticky right-0 z-10 bg-slate-700 w-14 min-w-[56px] px-3 py-2 text-center text-xs font-semibold">
+              <th className="sticky right-0 z-10 bg-slate-100 w-14 min-w-[56px] px-3 py-2 text-center text-xs font-semibold">
                 計
               </th>
             </tr>


### PR DESCRIPTION
bg-slate-800/text-white から bg-slate-50/text-slate-600 に変更し、
投手成績の表・試合結果画面の表ヘッダーの色に合わせる。

closes #31

https://claude.ai/code/session_01L7ukRzXQUrrGPGnThEPjZX