### PR TITLE
fix: 打撃成績テーブルのカラム順を打順・守備・選手に変更し、選手まで横スクロール固定

### DIFF
--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -276,12 +276,12 @@ export default function GameDetailPage() {
         <div className="rounded-2xl bg-white shadow-lg overflow-hidden">
           <h2 className="px-4 py-3 text-sm font-bold text-slate-600 border-b border-slate-200 bg-slate-50">打撃成績</h2>
           <div className="relative overflow-x-auto">
-            <table className="text-center text-sm border-collapse" style={{ minWidth: `${Math.max(400, 136 + maxInning * 56)}px` }}>
+            <table className="text-center text-sm border-collapse" style={{ minWidth: `${Math.max(400, 176 + maxInning * 56)}px` }}>
               <thead>
                 <tr className="border-b bg-slate-100">
                   <th className="sticky left-0 z-20 bg-slate-100 w-10 min-w-[40px] px-2 py-2 text-center border-r border-slate-200">打順</th>
-                  <th className="sticky left-10 z-20 bg-slate-100 w-24 min-w-[96px] px-2 py-2 text-left border-r border-slate-200">選手</th>
-                  <th className="w-10 min-w-[40px] px-1 py-2">守</th>
+                  <th className="sticky left-10 z-20 bg-slate-100 w-10 min-w-[40px] px-1 py-2 text-center border-r border-slate-200">守</th>
+                  <th className="sticky left-20 z-20 bg-slate-100 w-24 min-w-[96px] px-2 py-2 text-left border-r border-slate-200">選手</th>
                   {Array.from({ length: maxInning }, (_, i) => (
                     <th key={i} className="w-14 min-w-[56px] px-1 py-2">{i + 1}</th>
                   ))}
@@ -296,7 +296,8 @@ export default function GameDetailPage() {
                   return (
                     <tr key={order} className="border-b hover:bg-slate-50/50">
                       <td className="sticky left-0 z-10 bg-white w-10 min-w-[40px] px-2 py-2 text-center font-bold border-r border-slate-100">{order}</td>
-                      <td className="sticky left-10 z-10 bg-white w-24 min-w-[96px] px-2 py-2 text-left border-r border-slate-100">
+                      <td className="sticky left-10 z-10 bg-white w-10 min-w-[40px] px-1 py-2 text-slate-500 text-center border-r border-slate-100">{mainEntry?.position || "-"}</td>
+                      <td className="sticky left-20 z-10 bg-white w-24 min-w-[96px] px-2 py-2 text-left border-r border-slate-100">
                         <div className="truncate">
                           {mainEntry?.player_name || "-"}
                           {entries.length > 1 && (
@@ -306,7 +307,6 @@ export default function GameDetailPage() {
                           )}
                         </div>
                       </td>
-                      <td className="w-10 min-w-[40px] px-1 py-2 text-slate-500 text-center">{mainEntry?.position || "-"}</td>
                       {Array.from({ length: maxInning }, (_, inningIndex) => {
                         const inning = inningIndex + 1
                         const result = resultsMap.get(`${order}-${inning}`)


### PR DESCRIPTION
- ヘッダーと行のカラム順を「打順→選手→守」から「打順→守→選手」に変更
- 守備列に sticky left-10 z-20/z-10 を追加して横スクロール固定
- 選手列のオフセットを left-10 から left-20 (80px) に更新
- テーブルの minWidth を 136 から 176 に更新（固定列幅の合計に合わせる）

Closes #15

https://claude.ai/code/session_01VWZphaDxE56ULwUy67Knim