### PR TITLE
fix: iPhoneで長押し後に得点が変化しないバグを修正

### DIFF
--- a/components/score-input.tsx
+++ b/components/score-input.tsx
@@ -70,6 +70,17 @@ export function ScoreInput({
     }
   }, [])
 
+  const handleTouchEnd = useCallback((e: React.TouchEvent) => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current)
+      longPressTimerRef.current = null
+    }
+    // 長押し後にiOSが生成する合成 mousedown/click を抑制して二重更新を防ぐ
+    if (isLongPressRef.current) {
+      e.preventDefault()
+    }
+  }, [])
+
   const handleAddInning = () => {
     if (onTotalInningsChange && totalInnings < 15) {
       onTotalInningsChange(totalInnings + 1)
@@ -179,7 +190,8 @@ export function ScoreInput({
                     onMouseUp={handleLongPressEnd}
                     onMouseLeave={handleLongPressEnd}
                     onTouchStart={() => handleLongPressStart(inning, isFirstBatting ? "our" : "opponent")}
-                    onTouchEnd={handleLongPressEnd}
+                    onTouchEnd={handleTouchEnd}
+                    onTouchCancel={handleTouchEnd}
                     className={cn(
                       "w-full h-10 flex items-center justify-center",
                       "text-lg font-bold rounded-lg transition-all select-none",
@@ -221,7 +233,8 @@ export function ScoreInput({
                     onMouseUp={handleLongPressEnd}
                     onMouseLeave={handleLongPressEnd}
                     onTouchStart={() => handleLongPressStart(inning, !isFirstBatting ? "our" : "opponent")}
-                    onTouchEnd={handleLongPressEnd}
+                    onTouchEnd={handleTouchEnd}
+                    onTouchCancel={handleTouchEnd}
                     className={cn(
                       "w-full h-10 flex items-center justify-center",
                       "text-lg font-bold rounded-lg transition-all select-none",


### PR DESCRIPTION
iOSでは touchend の後に合成 mousedown/click が発火し、
handleLongPressStart 内で isLongPressRef がリセットされるため
長押し -1 が合成クリック +1 で打ち消されていた。

touchend 時に長押しが発生していた場合 preventDefault() を呼び出し、
iOSの合成マウスイベントを抑制することで二重更新を防ぐ。
onTouchCancel も追加してタッチキャンセル時のタイマー残存も解消。

Closes #41

https://claude.ai/code/session_014KeWkBR2zsHBDFMAUWhhvg