### PR TITLE
feat: 打者一巡（1イニング複数打席）に対応

### DIFF
--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -33,6 +33,7 @@ interface GameDetail {
   battingResults: Array<{
     batting_order: number
     inning: number
+    at_bat_sequence?: number
     hit_result: string
     direction?: string
     rbi_count: number
@@ -161,10 +162,28 @@ export default function GameDetailPage() {
 
   // 打撃結果をマップ化
   const resultsMap = new Map<string, typeof battingResults[0]>()
+  const atBatSeqsMap: Record<number, number> = {}
   for (const result of battingResults) {
-    resultsMap.set(`${result.batting_order}-${result.inning}`, result)
+    const seq = result.at_bat_sequence ?? 1
+    resultsMap.set(`${result.batting_order}-${result.inning}-${seq}`, result)
+    if (!atBatSeqsMap[result.inning] || atBatSeqsMap[result.inning] < seq) {
+      atBatSeqsMap[result.inning] = seq
+    }
   }
   const maxOrder = Math.max(9, ...lineupEntries.map(e => e.batting_order))
+
+  type AtBatColumn = { inning: number; sequence: number }
+  const columns: AtBatColumn[] = []
+  for (let i = 1; i <= maxInning; i++) {
+    const maxSeq = atBatSeqsMap[i] ?? 1
+    for (let s = 1; s <= maxSeq; s++) {
+      columns.push({ inning: i, sequence: s })
+    }
+  }
+  const lastColIndexByInning = new Map<number, number>()
+  columns.forEach((col, idx) => {
+    lastColIndexByInning.set(col.inning, idx)
+  })
 
   type DisplayRow = {
     battingOrder: number
@@ -355,15 +374,30 @@ export default function GameDetailPage() {
         <div className="rounded-2xl bg-white shadow-lg overflow-hidden">
           <h2 className="px-4 py-3 text-sm font-bold text-slate-600 border-b border-slate-200 bg-slate-50">打撃成績</h2>
           <div className="relative overflow-x-auto">
-            <table className="text-center text-sm border-collapse" style={{ minWidth: `${Math.max(400, 176 + maxInning * 56)}px` }}>
+            <table className="text-center text-sm border-collapse" style={{ minWidth: `${Math.max(400, 176 + columns.length * 56)}px` }}>
               <thead>
                 <tr className="border-b bg-slate-100">
                   <th className="sticky left-0 z-20 bg-slate-100 w-10 min-w-[40px] px-2 py-2 text-center border-r border-slate-200">打順</th>
                   <th className="sticky left-10 z-20 bg-slate-100 w-10 min-w-[40px] px-1 py-2 text-center border-r border-slate-200">守</th>
                   <th className="sticky left-20 z-20 bg-slate-100 w-24 min-w-[96px] px-2 py-2 text-left border-r border-slate-200">選手</th>
-                  {Array.from({ length: maxInning }, (_, i) => (
-                    <th key={i} className="w-14 min-w-[56px] px-1 py-2">{i + 1}</th>
-                  ))}
+                  {columns.map((col, idx) => {
+                    const isLastOfInning = lastColIndexByInning.get(col.inning) === idx
+                    return (
+                      <th
+                        key={`${col.inning}-${col.sequence}`}
+                        className={cn(
+                          "px-1 py-2",
+                          col.sequence === 1 ? "w-14 min-w-[56px]" : "w-10 min-w-[40px]",
+                          isLastOfInning && "border-r border-slate-200"
+                        )}
+                      >
+                        {col.sequence === 1
+                          ? col.inning
+                          : <span className="text-slate-400 text-[10px]">{["②", "③", "④", "⑤"][col.sequence - 2] ?? col.sequence}</span>
+                        }
+                      </th>
+                    )
+                  })}
                 </tr>
               </thead>
               <tbody>
@@ -382,17 +416,22 @@ export default function GameDetailPage() {
                       <td className="sticky left-20 z-10 bg-white w-24 min-w-[96px] px-2 py-2 text-left border-r border-slate-100">
                         <div className="truncate">{row.playerName}</div>
                       </td>
-                      {Array.from({ length: maxInning }, (_, inningIndex) => {
-                        const inning = inningIndex + 1
-                        const isActive = inning >= row.activeFrom && inning <= row.activeTo
+                      {columns.map((col, idx) => {
+                        const isActive = col.inning >= row.activeFrom && col.inning <= row.activeTo
+                        const isLastOfInning = lastColIndexByInning.get(col.inning) === idx
+                        const cellClass = cn(
+                          col.sequence === 1 ? "w-14 min-w-[56px]" : "w-10 min-w-[40px]",
+                          "px-1 py-2",
+                          isLastOfInning && "border-r border-slate-100"
+                        )
                         if (!isActive) {
                           return (
-                            <td key={inning} className="w-14 min-w-[56px] px-1 py-2 text-slate-300">-</td>
+                            <td key={`${col.inning}-${col.sequence}`} className={cn(cellClass, "text-slate-300")}>-</td>
                           )
                         }
-                        const result = resultsMap.get(`${row.battingOrder}-${inning}`)
+                        const result = resultsMap.get(`${row.battingOrder}-${col.inning}-${col.sequence}`)
                         if (!result) {
-                          return <td key={inning} className="w-14 min-w-[56px] px-1 py-2 text-slate-300">-</td>
+                          return <td key={`${col.inning}-${col.sequence}`} className={cn(cellClass, "text-slate-300")}>-</td>
                         }
                         const resultObj: BattingResult = {
                           hitResult: result.hit_result as BattingResult["hitResult"],
@@ -404,9 +443,10 @@ export default function GameDetailPage() {
                         const onBase = isOnBase(result.hit_result as BattingResult["hitResult"])
                         return (
                           <td
-                            key={inning}
+                            key={`${col.inning}-${col.sequence}`}
                             className={cn(
-                              "w-14 min-w-[56px] px-1 py-2 text-xs font-medium whitespace-nowrap",
+                              cellClass,
+                              "text-xs font-medium whitespace-nowrap",
                               hit && "text-green-700 bg-green-50",
                               !hit && onBase && "text-blue-700 bg-blue-50",
                               !hit && !onBase && "text-slate-600"

--- a/app/api/games/[id]/batting-result/route.ts
+++ b/app/api/games/[id]/batting-result/route.ts
@@ -9,7 +9,7 @@ export async function POST(
 ) {
   const { id: gameId } = await params
   const body = await request.json()
-  const { battingOrder, inning, result, shareToken } = body
+  const { battingOrder, inning, atBatSequence = 1, result, shareToken } = body
 
   // アクセス権チェック
   const session = await requireGameAccess(gameId, shareToken)
@@ -26,6 +26,7 @@ export async function POST(
     .eq("game_id", gameId)
     .eq("batting_order", battingOrder)
     .eq("inning", inning)
+    .eq("at_bat_sequence", atBatSequence)
 
   // 結果がある場合は挿入
   if (result && result.hitResult) {
@@ -35,6 +36,7 @@ export async function POST(
         game_id: gameId,
         batting_order: battingOrder,
         inning: inning,
+        at_bat_sequence: atBatSequence,
         hit_result: result.hitResult,
         direction: result.direction || null,
         rbi_count: result.rbiCount || 0,
@@ -64,6 +66,7 @@ export async function DELETE(
   const { searchParams } = new URL(request.url)
   const battingOrder = parseInt(searchParams.get("battingOrder") || "0")
   const inning = parseInt(searchParams.get("inning") || "0")
+  const atBatSequence = parseInt(searchParams.get("atBatSequence") || "1")
   const shareToken = searchParams.get("shareToken") || undefined
 
   const session = await requireGameAccess(gameId, shareToken)
@@ -79,6 +82,7 @@ export async function DELETE(
     .eq("game_id", gameId)
     .eq("batting_order", battingOrder)
     .eq("inning", inning)
+    .eq("at_bat_sequence", atBatSequence)
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 })

--- a/app/api/games/[id]/route.ts
+++ b/app/api/games/[id]/route.ts
@@ -170,6 +170,7 @@ export async function PUT(
       game_id: string
       batting_order: number
       inning: number
+      at_bat_sequence: number
       hit_result: string
       direction: string | null
       rbi_count: number
@@ -181,9 +182,12 @@ export async function PUT(
       stolen_home: boolean
       memo: string | null
     }> = []
-    
+
     for (const [key, result] of Object.entries(battingResults)) {
-      const [order, inning] = key.split("-").map(Number)
+      const parts = key.split("-")
+      const order = Number(parts[0])
+      const inning = Number(parts[1])
+      const atBatSeq = Number(parts[2] ?? 1)
       const r = result as {
         hitResult: string
         direction?: string
@@ -192,11 +196,12 @@ export async function PUT(
         stolenBases?: { second: boolean; third: boolean; home: boolean }
         memo?: string
       }
-      
+
       resultInserts.push({
         game_id: id,
         batting_order: order,
         inning: inning,
+        at_bat_sequence: atBatSeq,
         hit_result: r.hitResult,
         direction: r.direction || null,
         rbi_count: r.rbiCount || 0,

--- a/components/batting-grid.tsx
+++ b/components/batting-grid.tsx
@@ -2,37 +2,50 @@
 
 import { cn } from "@/lib/utils"
 import { Plus } from "lucide-react"
-import type { BattingResult, LineupSlot } from "@/lib/batting-types"
+import type { BattingResult, CellPosition, LineupSlot } from "@/lib/batting-types"
 import { getResultSummary, isHit, isOnBase } from "@/lib/batting-types"
+
+type AtBatColumn = { inning: number; sequence: number }
 
 interface BattingGridProps {
   results: Record<string, BattingResult>
-  onCellClick: (position: { battingOrder: number; inning: number }) => void
+  onCellClick: (position: CellPosition) => void
   lineupSlots: LineupSlot[]
   onPlayerClick: (order: number) => void
   onAddBattingOrder?: () => void
   totalInnings?: number
+  atBatSequences: Record<number, number>
+  onAddAtBat: (inning: number) => void
 }
 
-export function BattingGrid({ 
-  results, 
-  onCellClick, 
-  lineupSlots, 
+export function BattingGrid({
+  results,
+  onCellClick,
+  lineupSlots,
   onPlayerClick,
   onAddBattingOrder,
-  totalInnings = 9
+  totalInnings = 9,
+  atBatSequences,
+  onAddAtBat,
 }: BattingGridProps) {
   const maxBattingOrder = Math.max(lineupSlots.length, 9)
   const battingOrders = Array.from({ length: maxBattingOrder }, (_, i) => i + 1)
-  const innings = Array.from({ length: totalInnings }, (_, i) => i + 1)
 
-  const getResult = (battingOrder: number, inning: number): BattingResult | undefined => {
-    return results[`${battingOrder}-${inning}`]
+  const columns: AtBatColumn[] = []
+  for (let inning = 1; inning <= totalInnings; inning++) {
+    const maxSeq = atBatSequences[inning] ?? 1
+    for (let seq = 1; seq <= maxSeq; seq++) {
+      columns.push({ inning, sequence: seq })
+    }
+  }
+
+  const getResult = (battingOrder: number, col: AtBatColumn): BattingResult | undefined => {
+    return results[`${battingOrder}-${col.inning}-${col.sequence}`]
   }
 
   const getCellStyle = (result: BattingResult | undefined) => {
     if (!result) return ""
-    
+
     if (isHit(result.hitResult)) {
       return "bg-emerald-100 text-emerald-700"
     }
@@ -47,10 +60,10 @@ export function BattingGrid({
     if (!slot || slot.entries.length === 0) {
       return { name: "", position: "", hasSubstitute: false }
     }
-    
+
     const firstEntry = slot.entries[0]
     const hasSubstitute = slot.entries.length > 1
-    
+
     return {
       name: firstEntry.playerName,
       position: firstEntry.position || "",
@@ -58,11 +71,17 @@ export function BattingGrid({
     }
   }
 
+  // イニングごとの列インデックスを計算（ヘッダーのボーダー描画用）
+  const lastColIndexByInning = new Map<number, number>()
+  columns.forEach((col, idx) => {
+    lastColIndexByInning.set(col.inning, idx)
+  })
+
   return (
     <div className="rounded-xl bg-white shadow-sm border border-slate-200 overflow-hidden">
       <h2 className="px-4 py-3 text-sm font-bold text-slate-600 border-b border-slate-200 bg-slate-50">打撃成績</h2>
       <div className="overflow-x-auto">
-        <table className="w-full border-collapse" style={{ minWidth: `${Math.max(500, 136 + totalInnings * 48)}px` }}>
+        <table className="w-full border-collapse" style={{ minWidth: `${Math.max(500, 136 + columns.length * 48 + totalInnings * 28)}px` }}>
           <thead>
             <tr className="bg-slate-50 text-slate-600">
               <th className="sticky left-0 z-20 bg-slate-50 w-10 min-w-[40px] px-2 py-3 text-center text-xs font-semibold border-r border-slate-200">
@@ -74,14 +93,34 @@ export function BattingGrid({
               <th className="sticky left-20 z-20 bg-slate-50 w-24 min-w-[96px] px-2 py-3 text-center text-xs font-semibold border-r border-slate-200">
                 選手名
               </th>
-              {innings.map((inning) => (
-                <th
-                  key={inning}
-                  className="w-12 min-w-[48px] px-1 py-3 text-center text-xs font-semibold"
-                >
-                  {inning}
-                </th>
-              ))}
+              {columns.map((col, idx) => {
+                const isLastOfInning = lastColIndexByInning.get(col.inning) === idx
+                return (
+                  <th
+                    key={`${col.inning}-${col.sequence}`}
+                    className={cn(
+                      "px-1 py-1 text-center text-xs font-semibold",
+                      col.sequence === 1 ? "w-12 min-w-[48px]" : "w-10 min-w-[40px]",
+                      isLastOfInning && "border-r border-slate-200"
+                    )}
+                  >
+                    {col.sequence === 1 ? (
+                      <div className="flex flex-col items-center gap-0.5">
+                        <span>{col.inning}</span>
+                        <button
+                          onClick={() => onAddAtBat(col.inning)}
+                          className="flex h-4 w-4 items-center justify-center rounded text-slate-400 hover:text-blue-600 hover:bg-blue-50 transition-colors"
+                          title={`${col.inning}回に打席を追加`}
+                        >
+                          <Plus className="w-3 h-3" />
+                        </button>
+                      </div>
+                    ) : (
+                      <span className="text-slate-400 text-[10px]">{["②", "③", "④", "⑤"][col.sequence - 2] ?? col.sequence}</span>
+                    )}
+                  </th>
+                )
+              })}
             </tr>
           </thead>
           <tbody>
@@ -118,18 +157,22 @@ export function BattingGrid({
                       )}
                     </button>
                   </td>
-                  {innings.map((inning) => {
-                    const result = getResult(order, inning)
+                  {columns.map((col, idx) => {
+                    const result = getResult(order, col)
+                    const isLastOfInning = lastColIndexByInning.get(col.inning) === idx
                     return (
-                      <td key={inning} className="p-1">
+                      <td
+                        key={`${col.inning}-${col.sequence}`}
+                        className={cn("p-1", isLastOfInning && "border-r border-slate-100")}
+                      >
                         <button
-                          onClick={() => onCellClick({ battingOrder: order, inning })}
+                          onClick={() => onCellClick({ battingOrder: order, inning: col.inning, atBatSequence: col.sequence })}
                           className={cn(
                             "flex h-10 w-full items-center justify-center text-xs font-bold rounded-lg transition-all",
                             "hover:ring-2 hover:ring-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400",
                             result ? getCellStyle(result) : "text-slate-300 hover:bg-slate-50"
                           )}
-                          aria-label={`${order}番打者 ${inning}回の打席`}
+                          aria-label={`${order}番打者 ${col.inning}回${col.sequence > 1 ? ` (${col.sequence}打席目)` : ""}の打席`}
                         >
                           {result ? getResultSummary(result) : "-"}
                         </button>
@@ -151,7 +194,7 @@ export function BattingGrid({
                     打順を追加
                   </button>
                 </td>
-                <td colSpan={totalInnings}></td>
+                <td colSpan={columns.length}></td>
               </tr>
             )}
           </tbody>
@@ -175,6 +218,10 @@ export function BattingGrid({
         <div className="flex items-center gap-2 text-xs">
           <span className="h-3 w-1 rounded bg-amber-400" />
           <span className="text-slate-500">途中交代あり</span>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <Plus className="h-3 w-3 text-slate-400" />
+          <span className="text-slate-500">イニング内で打席を追加</span>
         </div>
       </div>
     </div>

--- a/components/batting-grid.tsx
+++ b/components/batting-grid.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { cn } from "@/lib/utils"
-import { Plus } from "lucide-react"
+import { Minus, Plus } from "lucide-react"
 import type { BattingResult, CellPosition, LineupSlot } from "@/lib/batting-types"
 import { getResultSummary, isHit, isOnBase } from "@/lib/batting-types"
 
@@ -16,6 +16,7 @@ interface BattingGridProps {
   totalInnings?: number
   atBatSequences: Record<number, number>
   onAddAtBat: (inning: number) => void
+  onRemoveAtBat: (inning: number) => void
 }
 
 export function BattingGrid({
@@ -27,6 +28,7 @@ export function BattingGrid({
   totalInnings = 9,
   atBatSequences,
   onAddAtBat,
+  onRemoveAtBat,
 }: BattingGridProps) {
   const maxBattingOrder = Math.max(lineupSlots.length, 9)
   const battingOrders = Array.from({ length: maxBattingOrder }, (_, i) => i + 1)
@@ -116,7 +118,18 @@ export function BattingGrid({
                         </button>
                       </div>
                     ) : (
-                      <span className="text-slate-400 text-[10px]">{["②", "③", "④", "⑤"][col.sequence - 2] ?? col.sequence}</span>
+                      <div className="flex flex-col items-center gap-0.5">
+                        <span className="text-slate-400 text-[10px]">{["②", "③", "④", "⑤"][col.sequence - 2] ?? col.sequence}</span>
+                        {isLastOfInning && (
+                          <button
+                            onClick={() => onRemoveAtBat(col.inning)}
+                            className="flex h-4 w-4 items-center justify-center rounded text-slate-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+                            title={`${col.inning}回の${col.sequence}打席目を削除`}
+                          >
+                            <Minus className="w-3 h-3" />
+                          </button>
+                        )}
+                      </div>
                     )}
                   </th>
                 )
@@ -221,7 +234,11 @@ export function BattingGrid({
         </div>
         <div className="flex items-center gap-2 text-xs">
           <Plus className="h-3 w-3 text-slate-400" />
-          <span className="text-slate-500">イニング内で打席を追加</span>
+          <span className="text-slate-500">打席を追加</span>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <Minus className="h-3 w-3 text-slate-400" />
+          <span className="text-slate-500">打席を削除</span>
         </div>
       </div>
     </div>

--- a/components/batting-input-dialog.tsx
+++ b/components/batting-input-dialog.tsx
@@ -142,7 +142,7 @@ export function BattingInputDialog({
         {/* 固定ヘッダー */}
         <DialogHeader className="sticky top-0 z-20 px-6 py-4 bg-gradient-to-r from-slate-800 to-slate-900 text-white flex-shrink-0">
           <DialogTitle className="text-center text-xl font-bold tracking-wide">
-            {position ? `${position.battingOrder}番打者 / ${position.inning}回` : "打席入力"}
+            {position ? `${position.battingOrder}番打者 / ${position.inning}回${(position.atBatSequence ?? 1) >= 2 ? ` (${position.atBatSequence}打席目)` : ""}` : "打席入力"}
           </DialogTitle>
         </DialogHeader>
 

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -446,6 +446,48 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
     }))
   }
 
+  const handleRemoveAtBat = async (inning: number) => {
+    const seq = atBatSequences[inning] ?? 1
+    if (seq <= 1) return
+
+    // 削除対象の打席結果キーを収集
+    const keysToDelete: { order: number; key: string }[] = []
+    for (let order = 1; order <= lineupSlots.length; order++) {
+      const key = `${order}-${inning}-${seq}`
+      if (results[key]) keysToDelete.push({ order, key })
+    }
+
+    // ローカル state から削除
+    setResults((prev) => {
+      const next = { ...prev }
+      for (const { key } of keysToDelete) delete next[key]
+      return next
+    })
+    setAtBatSequences((prev) => {
+      const next = { ...prev }
+      if (seq <= 2) delete next[inning]
+      else next[inning] = seq - 1
+      return next
+    })
+
+    // DB から削除
+    if (keysToDelete.length === 0) return
+    setSaveStatus("saving")
+    try {
+      await Promise.all(
+        keysToDelete.map(({ order }) =>
+          apiRequest(
+            `/api/games/${gameId}/batting-result?battingOrder=${order}&inning=${inning}&atBatSequence=${seq}${shareToken ? `&shareToken=${shareToken}` : ""}`,
+            "DELETE"
+          )
+        )
+      )
+      setSaveStatus("saved")
+    } catch {
+      setSaveStatus("error")
+    }
+  }
+
   // 共有URLを生成
   const handleGenerateShareUrl = async (): Promise<string | null> => {
     setIsGeneratingToken(true)
@@ -626,6 +668,7 @@ onTotalInningsChange={(value) => {
           totalInnings={totalInnings}
           atBatSequences={atBatSequences}
           onAddAtBat={handleAddAtBat}
+          onRemoveAtBat={handleRemoveAtBat}
         />
 
         <PitcherInput

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -46,6 +46,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
 
   // 打撃結果
   const [results, setResults] = useState<Record<string, BattingResult>>({})
+  const [atBatSequences, setAtBatSequences] = useState<Record<number, number>>({})
   const [selectedCell, setSelectedCell] = useState<CellPosition | null>(null)
   const [dialogOpen, setDialogOpen] = useState(false)
 
@@ -116,7 +117,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
     game?: { date: string; opponent: string; location: string; memo: string; is_first_batting: boolean; total_innings: number }
     inningScores?: { inning: number; our_score: number; opponent_score: number }[]
     lineupEntries?: { batting_order: number; player_id: string; player_name: string; position: string; is_substitute: boolean; entered_inning?: number; is_helper: boolean }[]
-    battingResults?: { batting_order: number; inning: number; hit_result: string; direction: string; rbi_count: number; runner_first: boolean; runner_second: boolean; runner_third: boolean; stolen_second: boolean; stolen_third: boolean; stolen_home: boolean }[]
+    battingResults?: { batting_order: number; inning: number; at_bat_sequence?: number; hit_result: string; direction: string; rbi_count: number; runner_first: boolean; runner_second: boolean; runner_third: boolean; stolen_second: boolean; stolen_third: boolean; stolen_home: boolean }[]
     pitcherResults?: { player_id?: string; player_name: string; innings_pitched: number; hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; pitch_count?: number; is_win: boolean; is_lose: boolean; is_save: boolean; is_hold: boolean }[]
   }) => {
     if (gameData.game) {
@@ -170,8 +171,10 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
 
     if (gameData.battingResults) {
       const newResults: Record<string, BattingResult> = {}
+      const newAtBatSeqs: Record<number, number> = {}
       for (const result of gameData.battingResults) {
-        const key = `${result.batting_order}-${result.inning}`
+        const seq = result.at_bat_sequence ?? 1
+        const key = `${result.batting_order}-${result.inning}-${seq}`
         newResults[key] = {
           hitResult: result.hit_result as HitResult,
           direction: result.direction as HitDirection | undefined,
@@ -187,8 +190,12 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
             home: result.stolen_home,
           },
         }
+        if (!newAtBatSeqs[result.inning] || newAtBatSeqs[result.inning] < seq) {
+          newAtBatSeqs[result.inning] = seq
+        }
       }
       setResults(newResults)
+      setAtBatSequences(newAtBatSeqs)
     }
 
     if (gameData.pitcherResults) {
@@ -264,8 +271,8 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
   // 打撃結果を都度保存
   const handleResultSave = async (result: BattingResult) => {
     if (!selectedCell) return
-    
-    const key = `${selectedCell.battingOrder}-${selectedCell.inning}`
+
+    const key = `${selectedCell.battingOrder}-${selectedCell.inning}-${selectedCell.atBatSequence}`
     setResults((prev) => ({
       ...prev,
       [key]: result,
@@ -278,6 +285,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
       await apiRequest(`/api/games/${gameId}/batting-result`, "POST", {
         battingOrder: selectedCell.battingOrder,
         inning: selectedCell.inning,
+        atBatSequence: selectedCell.atBatSequence,
         result,
       })
       setSaveStatus("saved")
@@ -289,8 +297,8 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
   // 打撃結果を削除
   const handleResultDelete = async () => {
     if (!selectedCell) return
-    
-    const key = `${selectedCell.battingOrder}-${selectedCell.inning}`
+
+    const key = `${selectedCell.battingOrder}-${selectedCell.inning}-${selectedCell.atBatSequence}`
     setResults((prev) => {
       const newResults = { ...prev }
       delete newResults[key]
@@ -302,7 +310,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
     setSaveStatus("saving")
     try {
       await apiRequest(
-        `/api/games/${gameId}/batting-result?battingOrder=${selectedCell.battingOrder}&inning=${selectedCell.inning}${shareToken ? `&shareToken=${shareToken}` : ""}`,
+        `/api/games/${gameId}/batting-result?battingOrder=${selectedCell.battingOrder}&inning=${selectedCell.inning}&atBatSequence=${selectedCell.atBatSequence}${shareToken ? `&shareToken=${shareToken}` : ""}`,
         "DELETE"
       )
       setSaveStatus("saved")
@@ -431,6 +439,13 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
     setLineupSlots((prev) => [...prev, { order: newOrder, entries: [] }])
   }
 
+  const handleAddAtBat = (inning: number) => {
+    setAtBatSequences((prev) => ({
+      ...prev,
+      [inning]: (prev[inning] ?? 1) + 1,
+    }))
+  }
+
   // 共有URLを生成
   const handleGenerateShareUrl = async (): Promise<string | null> => {
     setIsGeneratingToken(true)
@@ -477,7 +492,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
   }
 
   const currentResult = selectedCell
-    ? results[`${selectedCell.battingOrder}-${selectedCell.inning}`]
+    ? results[`${selectedCell.battingOrder}-${selectedCell.inning}-${selectedCell.atBatSequence}`]
     : undefined
 
   const currentLineupSlot = selectedLineupOrder !== null
@@ -602,13 +617,15 @@ onTotalInningsChange={(value) => {
           }}
         />
 
-        <BattingGrid 
-          results={results} 
+        <BattingGrid
+          results={results}
           onCellClick={handleCellClick}
           lineupSlots={lineupSlots}
           onPlayerClick={handlePlayerClick}
           onAddBattingOrder={handleAddBattingOrder}
           totalInnings={totalInnings}
+          atBatSequences={atBatSequences}
+          onAddAtBat={handleAddAtBat}
         />
 
         <PitcherInput

--- a/lib/batting-types.ts
+++ b/lib/batting-types.ts
@@ -50,6 +50,7 @@ export interface BattingResult {
 export interface CellPosition {
   battingOrder: number
   inning: number
+  atBatSequence: number
 }
 
 // 守備位置

--- a/scripts/002_add_at_bat_sequence.sql
+++ b/scripts/002_add_at_bat_sequence.sql
@@ -1,0 +1,12 @@
+-- batting_results テーブルに at_bat_sequence カラムを追加
+-- 打者一巡（1イニング中に同じ打者が複数回打席に立つ）に対応
+ALTER TABLE batting_results
+  ADD COLUMN IF NOT EXISTS at_bat_sequence INTEGER NOT NULL DEFAULT 1;
+
+-- 既存の UNIQUE 制約を削除して at_bat_sequence を含む制約に更新
+ALTER TABLE batting_results
+  DROP CONSTRAINT IF EXISTS batting_results_game_id_batting_order_inning_key;
+
+ALTER TABLE batting_results
+  ADD CONSTRAINT batting_results_game_id_batting_order_inning_seq_key
+  UNIQUE (game_id, batting_order, inning, at_bat_sequence);


### PR DESCRIPTION
イニングヘッダーの「＋」ボタンで同イニング内に打席列を追加できるようにした。

- CellPosition に atBatSequence を追加し、結果キーを `${order}-${inning}-${seq}` に変更
- batting_results テーブルに at_bat_sequence カラム追加・UNIQUE制約更新（002_add_at_bat_sequence.sql）
- BattingGrid を AtBatColumn（inning×sequence）ベースの列管理に刷新
- game-editor に atBatSequences 状態と handleAddAtBat ハンドラを追加
- 打席入力ダイアログで2打席目以降は「(N打席目)」と表示
- 試合結果表示ページも複数打席列に対応

Closes #51

https://claude.ai/code/session_01TjsoqMMoftUsQXHKYrfLqK