### PR TITLE
feat: 投手の助っ人機能を追加（Issue #32）

### DIFF
--- a/app/api/games/[id]/pitchers/route.ts
+++ b/app/api/games/[id]/pitchers/route.ts
@@ -18,6 +18,7 @@ interface PitcherResult {
   isLose?: boolean
   isSave?: boolean
   isHold?: boolean
+  isHelper?: boolean
 }
 
 // 投手成績を保存（都度保存用 - 全体を置き換え）
@@ -68,6 +69,7 @@ export async function POST(
         is_lose: p.isLose || false,
         is_save: p.isSave || false,
         is_hold: p.isHold || false,
+        is_helper: p.isHelper || false,
         order_index: index,
       }))
 

--- a/app/api/games/[id]/route.ts
+++ b/app/api/games/[id]/route.ts
@@ -238,6 +238,7 @@ export async function PUT(
       isLose?: boolean
       isSave?: boolean
       isHold?: boolean
+      isHelper?: boolean
     }, index: number) => ({
       game_id: id,
       player_id: p.playerId && p.playerId.trim() !== "" ? p.playerId : null,
@@ -255,6 +256,7 @@ export async function PUT(
       is_lose: p.isLose || false,
       is_save: p.isSave || false,
       is_hold: p.isHold || false,
+      is_helper: p.isHelper || false,
       order_index: index,
     }))
     await supabase.from("pitcher_results").insert(pitcherInserts)

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -178,6 +178,7 @@ export async function POST(request: Request) {
         isLose?: boolean
         isSave?: boolean
         isHold?: boolean
+        isHelper?: boolean
       }, index: number) => ({
         game_id: gameId,
         player_id: p.playerId && p.playerId.trim() !== "" ? p.playerId : null,
@@ -195,6 +196,7 @@ export async function POST(request: Request) {
         is_lose: p.isLose || false,
         is_save: p.isSave || false,
         is_hold: p.isHold || false,
+        is_helper: p.isHelper || false,
         order_index: index,
       }))
 

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -128,8 +128,8 @@ export async function GET(request: Request) {
   // 打席数でソート
   battingStatsResponse.sort((a, b) => b.stats.plateAppearances - a.stats.plateAppearances)
 
-  // 投手成績を取得（選手名JOINで解決）
-  let pitcherQuery = supabase.from("pitcher_results").select("*, players(name)")
+  // 投手成績を取得（助っ人を除外、選手名JOINで解決）
+  let pitcherQuery = supabase.from("pitcher_results").select("*, players(name)").eq("is_helper", false)
   if (teamId && gameIds.length > 0) {
     pitcherQuery = pitcherQuery.in("game_id", gameIds)
   }

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -118,7 +118,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
     inningScores?: { inning: number; our_score: number; opponent_score: number }[]
     lineupEntries?: { batting_order: number; player_id: string; player_name: string; position: string; is_substitute: boolean; entered_inning?: number; is_helper: boolean }[]
     battingResults?: { batting_order: number; inning: number; at_bat_sequence?: number; hit_result: string; direction: string; rbi_count: number; runner_first: boolean; runner_second: boolean; runner_third: boolean; stolen_second: boolean; stolen_third: boolean; stolen_home: boolean }[]
-    pitcherResults?: { player_id?: string; player_name: string; innings_pitched: number; hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; pitch_count?: number; is_win: boolean; is_lose: boolean; is_save: boolean; is_hold: boolean }[]
+    pitcherResults?: { player_id?: string; player_name: string; innings_pitched: number; hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; pitch_count?: number; is_win: boolean; is_lose: boolean; is_save: boolean; is_hold: boolean; is_helper?: boolean }[]
   }) => {
     if (gameData.game) {
       setGameDate(gameData.game.date || "")
@@ -215,6 +215,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
         isLose: p.is_lose,
         isSave: p.is_save,
         isHold: p.is_hold,
+        isHelper: p.is_helper || false,
       })))
     }
   }, [])

--- a/components/pitcher-input.tsx
+++ b/components/pitcher-input.tsx
@@ -47,6 +47,7 @@ export function PitcherInput({
       walks: 0,
       hitByPitch: 0,
       homeRuns: 0,
+      isHelper: false,
     })
     setIsDialogOpen(true)
   }
@@ -187,7 +188,14 @@ export function PitcherInput({
                   className="hover:bg-slate-50 cursor-pointer transition-colors"
                   onClick={() => handleEdit(index)}
                 >
-                  <td className="px-3 py-2 font-medium text-slate-800">{pitcher.playerName}</td>
+                  <td className="px-3 py-2 font-medium text-slate-800">
+                    <div className="flex items-center gap-1.5">
+                      {pitcher.playerName}
+                      {pitcher.isHelper && (
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-600 font-medium">助っ人</span>
+                      )}
+                    </div>
+                  </td>
                   <td className="px-2 py-2 text-center">{formatInnings(pitcher.inningsPitched)}</td>
                   <td className="px-2 py-2 text-center">{pitcher.hits}</td>
                   <td className="px-2 py-2 text-center">{pitcher.runs}</td>
@@ -231,33 +239,52 @@ export function PitcherInput({
             {/* 選手名 */}
             <div>
               <label className="text-sm font-semibold text-slate-700 mb-2 block">選手名</label>
-              {registeredPlayers.length > 0 ? (
-                <select
-                  value={form.playerId}
-                  onChange={(e) => {
-                    const player = registeredPlayers.find(p => p.id === e.target.value)
-                    if (player) {
-                      setForm({ ...form, playerId: player.id, playerName: player.name })
-                    }
-                  }}
-                  className="w-full h-12 px-4 rounded-xl border border-slate-200 bg-slate-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white transition-all text-slate-800"
-                >
-<option value="">選手を選択</option>
-                {sortPlayersByNumber(registeredPlayers).map((player) => (
-                  <option key={player.id} value={player.id}>
-                    {player.number ? `${player.number} ` : ""}{player.name}
-                  </option>
-                  ))}
-                </select>
-              ) : (
-                <input
-                  type="text"
-                  value={form.playerName}
-                  onChange={(e) => setForm({ ...form, playerName: e.target.value })}
-                  placeholder="選手名を入力"
-                  className="w-full h-12 px-4 rounded-xl border border-slate-200 bg-slate-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white transition-all text-slate-800 placeholder:text-slate-400"
-                />
+              {!form.isHelper && (
+                registeredPlayers.length > 0 ? (
+                  <select
+                    value={form.playerId}
+                    onChange={(e) => {
+                      const player = registeredPlayers.find(p => p.id === e.target.value)
+                      if (player) {
+                        setForm({ ...form, playerId: player.id, playerName: player.name, isHelper: false })
+                      }
+                    }}
+                    className="w-full h-12 px-4 rounded-xl border border-slate-200 bg-slate-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white transition-all text-slate-800"
+                  >
+                    <option value="">選手を選択</option>
+                    {sortPlayersByNumber(registeredPlayers).map((player) => (
+                      <option key={player.id} value={player.id}>
+                        {player.number ? `${player.number} ` : ""}{player.name}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type="text"
+                    value={form.playerName}
+                    onChange={(e) => setForm({ ...form, playerName: e.target.value })}
+                    placeholder="選手名を入力"
+                    className="w-full h-12 px-4 rounded-xl border border-slate-200 bg-slate-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white transition-all text-slate-800 placeholder:text-slate-400"
+                  />
+                )
               )}
+              <button
+                onClick={() => {
+                  if (form.isHelper) {
+                    setForm({ ...form, playerId: "", playerName: "", isHelper: false })
+                  } else {
+                    setForm({ ...form, playerId: "", playerName: "助っ人", isHelper: true })
+                  }
+                }}
+                className={cn(
+                  "mt-2 text-xs px-3 py-1.5 rounded-lg transition-all",
+                  form.isHelper
+                    ? "bg-purple-50 text-purple-600 border border-purple-300 font-medium"
+                    : "text-slate-400 border border-dashed border-slate-300 hover:border-slate-400 hover:text-slate-500"
+                )}
+              >
+                {form.isHelper ? "✓ 助っ人" : "助っ人として登録"}
+              </button>
             </div>
 
             {/* 投球回 */}

--- a/lib/batting-types.ts
+++ b/lib/batting-types.ts
@@ -125,6 +125,7 @@ export interface PitcherResult {
   isLose?: boolean            // 敗戦
   isSave?: boolean            // セーブ
   isHold?: boolean            // ホールド
+  isHelper?: boolean          // 助っ人（個人成績に含めない）
 }
 
 // 結果の短縮表示を生成

--- a/scripts/003_add_is_helper_to_pitcher_results.sql
+++ b/scripts/003_add_is_helper_to_pitcher_results.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pitcher_results ADD COLUMN IF NOT EXISTS is_helper BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
野手と同様に、投手にも助っ人フラグ（is_helper）を追加する。

- pitcher_results テーブルに is_helper カラムを追加するSQLスクリプトを作成
- PitcherResult 型に isHelper?: boolean を追加
- PitcherInput コンポーネントに助っ人トグルボタンと一覧バッジを追加
- 投手保存API（pitchers/route.ts、games/[id]/route.ts、games/route.ts）で is_helper を永続化
- game-editor.tsx の applyGameData で isHelper をマッピング
- 統計API（stats/route.ts）で助っ人投手を個人成績から除外

Closes #32

https://claude.ai/code/session_016gdB9WqhXegJQk4fCz6HAw