### PR TITLE
Add scored flag to batting results tracking

### DIFF
--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -39,6 +39,7 @@ interface GameDetail {
     hit_result: string
     direction?: string
     rbi_count: number
+    scored?: boolean
   }>
   pitcherResults: Array<{
     player_name: string
@@ -458,6 +459,7 @@ export default function GameDetailPage() {
                           hitResult: result.hit_result as BattingResult["hitResult"],
                           direction: result.direction as BattingResult["direction"],
                           rbiCount: result.rbi_count,
+                          scored: result.scored,
                         }
                         const summary = getResultSummary(resultObj)
                         const hit = isHit(result.hit_result as BattingResult["hitResult"])

--- a/app/[teamId]/stats/page.tsx
+++ b/app/[teamId]/stats/page.tsx
@@ -40,6 +40,7 @@ const BATTING_COLUMNS: Array<{
   { key: "triples", label: "三塁打", shortLabel: "三", format: (v) => v.toString() },
   { key: "homeRuns", label: "本塁打", shortLabel: "本", format: (v) => v.toString() },
   { key: "rbi", label: "打点", shortLabel: "点", format: (v) => v.toString(), primary: true },
+  { key: "runs", label: "得点", shortLabel: "得", format: (v) => v.toString() },
   { key: "walks", label: "四球", shortLabel: "四", format: (v) => v.toString() },
   { key: "strikeouts", label: "三振", shortLabel: "振", format: (v) => v.toString() },
   { key: "stolenBases", label: "盗塁", shortLabel: "盗", format: (v) => v.toString() },

--- a/app/api/games/[id]/batting-result/route.ts
+++ b/app/api/games/[id]/batting-result/route.ts
@@ -40,6 +40,7 @@ export async function POST(
         hit_result: result.hitResult,
         direction: result.direction || null,
         rbi_count: result.rbiCount || 0,
+        scored: result.scored || false,
         runner_first: result.runners?.first || false,
         runner_second: result.runners?.second || false,
         runner_third: result.runners?.third || false,

--- a/app/api/games/[id]/route.ts
+++ b/app/api/games/[id]/route.ts
@@ -174,6 +174,7 @@ export async function PUT(
       hit_result: string
       direction: string | null
       rbi_count: number
+      scored: boolean
       runner_first: boolean
       runner_second: boolean
       runner_third: boolean
@@ -192,6 +193,7 @@ export async function PUT(
         hitResult: string
         direction?: string
         rbiCount: number
+        scored?: boolean
         runners?: { first: boolean; second: boolean; third: boolean }
         stolenBases?: { second: boolean; third: boolean; home: boolean }
         memo?: string
@@ -205,6 +207,7 @@ export async function PUT(
         hit_result: r.hitResult,
         direction: r.direction || null,
         rbi_count: r.rbiCount || 0,
+        scored: r.scored || false,
         runner_first: r.runners?.first || false,
         runner_second: r.runners?.second || false,
         runner_third: r.runners?.third || false,

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -77,6 +77,7 @@ export async function GET(request: Request) {
     results: Array<{
       hit_result: HitResult
       rbi_count: number
+      scored?: boolean
       stolen_second?: boolean
       stolen_third?: boolean
       stolen_home?: boolean
@@ -106,6 +107,7 @@ export async function GET(request: Request) {
     playerData.results.push({
       hit_result: result.hit_result as HitResult,
       rbi_count: result.rbi_count || 0,
+      scored: result.scored,
       stolen_second: result.stolen_second,
       stolen_third: result.stolen_third,
       stolen_home: result.stolen_home,

--- a/components/batting-input-dialog.tsx
+++ b/components/batting-input-dialog.tsx
@@ -60,6 +60,7 @@ export function BattingInputDialog({
   const [hitResult, setHitResult] = useState<HitResult | null>(null)
   const [direction, setDirection] = useState<HitDirection | undefined>(undefined)
   const [rbiCount, setRbiCount] = useState<number>(0)
+  const [scored, setScored] = useState<boolean>(false)
   const [runners, setRunners] = useState<RunnerState>({ first: false, second: false, third: false })
   const [stolenBases, setStolenBases] = useState<StolenBase>({ second: false, third: false, home: false })
 
@@ -68,12 +69,14 @@ export function BattingInputDialog({
       setHitResult(existingResult.hitResult)
       setDirection(existingResult.direction)
       setRbiCount(existingResult.rbiCount)
+      setScored(existingResult.scored || false)
       setRunners(existingResult.runners || { first: false, second: false, third: false })
       setStolenBases(existingResult.stolenBases || { second: false, third: false, home: false })
     } else {
       setHitResult(null)
       setDirection(undefined)
       setRbiCount(0)
+      setScored(false)
       setRunners({ first: false, second: false, third: false })
       setStolenBases({ second: false, third: false, home: false })
     }
@@ -85,6 +88,7 @@ export function BattingInputDialog({
       hitResult,
       direction,
       rbiCount,
+      scored,
       runners,
       stolenBases,
     })
@@ -419,6 +423,22 @@ export function BattingInputDialog({
                 </button>
               ))}
             </div>
+          </div>
+
+          {/* 得点 */}
+          <div className="space-y-2">
+            <div className="text-sm font-bold text-slate-700">得点</div>
+            <button
+              onClick={() => setScored(prev => !prev)}
+              className={cn(
+                "h-12 px-6 rounded-xl font-bold text-sm transition-all duration-200",
+                scored
+                  ? "bg-rose-500 text-white shadow-lg scale-105"
+                  : "bg-white border-2 border-slate-200 text-slate-600 hover:border-rose-400"
+              )}
+            >
+              {scored ? "得点あり" : "得点なし"}
+            </button>
           </div>
 
           {/* 盗塁 */}

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -119,7 +119,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
     game?: { date: string; opponent: string; location: string; memo: string; is_first_batting: boolean; total_innings: number }
     inningScores?: { inning: number; our_score: number; opponent_score: number }[]
     lineupEntries?: { batting_order: number; player_id: string; player_name: string; position: string; is_substitute: boolean; entered_inning?: number; is_helper: boolean }[]
-    battingResults?: { batting_order: number; inning: number; at_bat_sequence?: number; hit_result: string; direction: string; rbi_count: number; runner_first: boolean; runner_second: boolean; runner_third: boolean; stolen_second: boolean; stolen_third: boolean; stolen_home: boolean }[]
+    battingResults?: { batting_order: number; inning: number; at_bat_sequence?: number; hit_result: string; direction: string; rbi_count: number; scored?: boolean; runner_first: boolean; runner_second: boolean; runner_third: boolean; stolen_second: boolean; stolen_third: boolean; stolen_home: boolean }[]
     pitcherResults?: { player_id?: string; player_name: string; innings_pitched: number; hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; pitch_count?: number; is_win: boolean; is_lose: boolean; is_save: boolean; is_hold: boolean; is_helper?: boolean }[]
   }) => {
     if (gameData.game) {
@@ -181,6 +181,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
           hitResult: result.hit_result as HitResult,
           direction: result.direction as HitDirection | undefined,
           rbiCount: result.rbi_count,
+          scored: result.scored || false,
           runners: {
             first: result.runner_first,
             second: result.runner_second,

--- a/lib/batting-types.ts
+++ b/lib/batting-types.ts
@@ -42,6 +42,7 @@ export interface BattingResult {
   hitResult: HitResult
   direction?: HitDirection
   rbiCount: number
+  scored?: boolean
   runners?: RunnerState
   stolenBases?: StolenBase
   memo?: string

--- a/lib/batting-types.ts
+++ b/lib/batting-types.ts
@@ -131,8 +131,8 @@ export interface PitcherResult {
 
 // 結果の短縮表示を生成
 export function getResultSummary(result: BattingResult): string {
-  const { hitResult, direction, rbiCount } = result
-  
+  const { hitResult, direction, rbiCount, scored } = result
+
   // 短縮形の変換
   const shortResult: Record<HitResult, string> = {
     "単打": "安",
@@ -153,17 +153,22 @@ export function getResultSummary(result: BattingResult): string {
   }
 
   let summary = shortResult[hitResult] || hitResult
-  
+
   // 方向がある場合は追加
   if (direction) {
     summary = `${direction}${summary}`
   }
-  
+
   // 打点がある場合は追加
   if (rbiCount > 0) {
     summary += `(${rbiCount})`
   }
-  
+
+  // 得点がある場合は末尾に追加
+  if (scored) {
+    summary += "●"
+  }
+
   return summary
 }
 

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -14,6 +14,7 @@ export interface BattingStats {
   triples: number         // 三塁打
   homeRuns: number        // 本塁打
   rbi: number             // 打点
+  runs: number            // 得点
   walks: number           // 四球
   hitByPitch: number      // 死球
   strikeouts: number      // 三振
@@ -41,6 +42,7 @@ export function calculateBattingStats(
   battingResults: Array<{
     hit_result: HitResult
     rbi_count: number
+    scored?: boolean
     stolen_second?: boolean
     stolen_third?: boolean
     stolen_home?: boolean
@@ -56,6 +58,7 @@ export function calculateBattingStats(
     triples: 0,
     homeRuns: 0,
     rbi: 0,
+    runs: 0,
     walks: 0,
     hitByPitch: 0,
     strikeouts: 0,
@@ -71,7 +74,8 @@ export function calculateBattingStats(
   for (const result of battingResults) {
     stats.plateAppearances++
     stats.rbi += result.rbi_count || 0
-    
+    if (result.scored) stats.runs++
+
     // 盗塁カウント
     if (result.stolen_second) stats.stolenBases++
     if (result.stolen_third) stats.stolenBases++

--- a/scripts/004_add_scored_to_batting_results.sql
+++ b/scripts/004_add_scored_to_batting_results.sql
@@ -1,0 +1,2 @@
+-- batting_resultsテーブルに得点フラグを追加
+ALTER TABLE batting_results ADD COLUMN IF NOT EXISTS scored BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
## Summary
This PR adds the ability to track whether a batter scored a run during their at-bat. A new `scored` boolean field has been added throughout the batting results system, allowing users to mark when a batter reaches home plate.

## Key Changes
- **UI Enhancement**: Added a toggle button in the batting input dialog to mark whether a batter scored (得点)
- **Data Model**: Extended `BattingResult` interface with optional `scored` boolean field
- **Statistics**: Added `runs` field to `BattingStats` to track total runs scored by a player
- **Result Summary**: Updated `getResultSummary()` to append a "●" indicator when a batter scored
- **Database**: Added migration script to add `scored` column to `batting_results` table with default value of `FALSE`
- **API Routes**: Updated all relevant API endpoints to handle the new `scored` field:
  - Game update endpoint
  - Batting result creation endpoint
  - Stats calculation endpoint
- **UI Components**: Updated game editor and game detail page to display and manage the scored flag

## Implementation Details
- The `scored` field is optional in the data model for backward compatibility
- The toggle button uses a rose/pink color scheme when active to match the existing UI design
- Statistics calculation automatically increments the `runs` counter when `scored` is true
- The scored indicator (●) is appended to the result summary for quick visual reference in game records

https://claude.ai/code/session_01NcxGRywE8qkgM5dsjVjaJu