### PR TITLE
feat: 途中守備交代・複数守備位置対応 (#65)

### DIFF
--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -28,7 +28,7 @@ interface GameDetail {
   lineupEntries: Array<{
     batting_order: number
     player_name: string
-    position?: string
+    positions?: string[]
     is_substitute: boolean
     entered_inning?: number
   }>
@@ -201,7 +201,7 @@ export default function GameDetailPage() {
   type DisplayRow = {
     battingOrder: number
     playerName: string
-    position: string | undefined
+    positions: string[]
     activeFrom: number
     activeTo: number
     isStarter: boolean
@@ -220,7 +220,7 @@ export default function GameDetailPage() {
       displayRows.push({
         battingOrder: order,
         playerName: "-",
-        position: undefined,
+        positions: [],
         activeFrom: 1,
         activeTo: maxInning,
         isStarter: false,
@@ -236,7 +236,7 @@ export default function GameDetailPage() {
       displayRows.push({
         battingOrder: order,
         playerName: entry.player_name,
-        position: entry.position,
+        positions: entry.positions ?? [],
         activeFrom,
         activeTo,
         isStarter: !entry.is_substitute,
@@ -432,8 +432,16 @@ export default function GameDetailPage() {
                       <td className="sticky left-0 z-10 bg-white w-10 min-w-[40px] px-2 py-2 text-center font-bold border-r border-slate-100">
                         {row.isStarter ? `(${row.battingOrder})` : row.battingOrder}
                       </td>
-                      <td className="sticky left-10 z-10 bg-white w-10 min-w-[40px] px-1 py-2 text-slate-500 text-center border-r border-slate-100">
-                        {row.position ?? "-"}
+                      <td className="sticky left-10 z-10 bg-white w-10 min-w-[40px] px-1 py-2 text-center border-r border-slate-100">
+                        {row.positions.length > 0 ? (
+                          <div className="flex gap-0.5 justify-center flex-wrap">
+                            {row.positions.map((p, i) => (
+                              <span key={i} className="text-xs font-medium text-slate-600">{p}</span>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="text-slate-300 text-xs">-</span>
+                        )}
                       </td>
                       <td className="sticky left-20 z-10 bg-white w-24 min-w-[96px] px-2 py-2 text-left border-r border-slate-100">
                         <div className="truncate">{row.playerName}</div>

--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -434,9 +434,9 @@ export default function GameDetailPage() {
                       </td>
                       <td className="sticky left-10 z-10 bg-white w-10 min-w-[40px] px-1 py-2 text-center border-r border-slate-100">
                         {row.positions.length > 0 ? (
-                          <div className="flex gap-0.5 justify-center flex-wrap">
+                          <div className="flex gap-0.5 justify-center flex-nowrap overflow-hidden">
                             {row.positions.map((p, i) => (
-                              <span key={i} className="text-xs font-medium text-slate-600">{p}</span>
+                              <span key={i} className="text-xs font-medium text-slate-600 shrink-0">{p}</span>
                             ))}
                           </div>
                         ) : (

--- a/app/api/games/[id]/lineup/route.ts
+++ b/app/api/games/[id]/lineup/route.ts
@@ -5,7 +5,7 @@ import { requireGameAccess } from "@/lib/auth"
 interface LineupEntry {
   playerId?: string
   playerName: string
-  position?: string
+  positions?: string[]
   isSubstitute?: boolean
   enteredInning?: number
   isHelper?: boolean
@@ -49,7 +49,7 @@ export async function POST(
         batting_order: battingOrder,
         player_id: entry.playerId || null,
         player_name: entry.playerName,
-        position: entry.position || null,
+        positions: entry.positions && entry.positions.length > 0 ? entry.positions : null,
         is_substitute: entry.isSubstitute || false,
         entered_inning: entry.enteredInning || null,
         is_helper: entry.isHelper || false,

--- a/app/api/games/[id]/route.ts
+++ b/app/api/games/[id]/route.ts
@@ -138,7 +138,7 @@ export async function PUT(
       batting_order: number
       player_id: string | null
       player_name: string
-      position: string | null
+      positions: string[] | null
       is_substitute: boolean
       entered_inning: number | null
       is_helper: boolean
@@ -151,7 +151,7 @@ export async function PUT(
           batting_order: slot.order,
           player_id: entry.playerId || null,
           player_name: entry.playerName,
-          position: entry.position || null,
+          positions: entry.positions && entry.positions.length > 0 ? entry.positions : null,
           is_substitute: entry.isSubstitute || false,
           entered_inning: entry.enteredInning || null,
           is_helper: entry.isHelper || false,

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -88,12 +88,12 @@ export async function POST(request: Request) {
       batting_order: number
       player_id: string | null
       player_name: string
-      position: string | null
+      positions: string[] | null
       is_substitute: boolean
       entered_inning: number | null
     }[] = []
-    
-    lineupSlots.forEach((slot: { order: number; entries: Array<{ playerId: string; playerName: string; position?: string; isSubstitute?: boolean; enteredInning?: number }> }) => {
+
+    lineupSlots.forEach((slot: { order: number; entries: Array<{ playerId: string; playerName: string; positions?: string[]; isSubstitute?: boolean; enteredInning?: number }> }) => {
       slot.entries.forEach((entry) => {
         if (entry.playerName && entry.playerName.trim() !== "") {
           lineupData.push({
@@ -101,7 +101,7 @@ export async function POST(request: Request) {
             batting_order: slot.order,
             player_id: entry.playerId || null,
             player_name: entry.playerName,
-            position: entry.position || null,
+            positions: entry.positions && entry.positions.length > 0 ? entry.positions : null,
             is_substitute: entry.isSubstitute || false,
             entered_inning: entry.enteredInning || null,
           })

--- a/components/batting-grid.tsx
+++ b/components/batting-grid.tsx
@@ -60,7 +60,7 @@ export function BattingGrid({
   const getSlotDisplay = (order: number) => {
     const slot = lineupSlots.find((s) => s.order === order)
     if (!slot || slot.entries.length === 0) {
-      return { name: "", position: "", hasSubstitute: false }
+      return { name: "", positions: [] as string[], hasSubstitute: false }
     }
 
     const firstEntry = slot.entries[0]
@@ -68,7 +68,7 @@ export function BattingGrid({
 
     return {
       name: firstEntry.playerName,
-      position: firstEntry.position || "",
+      positions: firstEntry.positions ?? [],
       hasSubstitute,
     }
   }
@@ -138,7 +138,7 @@ export function BattingGrid({
           </thead>
           <tbody>
             {battingOrders.map((order) => {
-              const { name, position, hasSubstitute } = getSlotDisplay(order)
+              const { name, positions, hasSubstitute } = getSlotDisplay(order)
               return (
                 <tr key={order} className="hover:bg-slate-50/50 transition-colors border-b border-slate-100">
                   <td className="sticky left-0 z-10 bg-slate-50 w-10 min-w-[40px] px-2 py-2 text-center border-r border-slate-200">
@@ -147,12 +147,16 @@ export function BattingGrid({
                     </span>
                   </td>
                   <td className="sticky left-10 z-10 bg-slate-50 w-10 min-w-[40px] px-1 py-1 text-center border-r border-slate-200">
-                    <span className={cn(
-                      "inline-flex h-7 w-7 items-center justify-center rounded text-xs font-bold",
-                      position ? "bg-emerald-100 text-emerald-700" : "text-slate-300"
-                    )}>
-                      {position || "-"}
-                    </span>
+                    {positions.length > 0 ? (
+                      <span className="inline-flex h-7 items-center gap-0.5 px-1 rounded text-xs font-bold bg-emerald-100 text-emerald-700">
+                        {positions[0]}
+                        {positions.length > 1 && (
+                          <span className="text-[10px] text-emerald-500">+</span>
+                        )}
+                      </span>
+                    ) : (
+                      <span className="text-slate-300 text-xs">-</span>
+                    )}
                   </td>
                   <td className="sticky left-20 z-10 bg-white w-24 min-w-[96px] px-1 py-1 border-r border-slate-200">
                     <button

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -118,7 +118,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
   const applyGameData = useCallback((gameData: {
     game?: { date: string; opponent: string; location: string; memo: string; is_first_batting: boolean; total_innings: number }
     inningScores?: { inning: number; our_score: number; opponent_score: number }[]
-    lineupEntries?: { batting_order: number; player_id: string; player_name: string; position: string; is_substitute: boolean; entered_inning?: number; is_helper: boolean }[]
+    lineupEntries?: { batting_order: number; player_id: string; player_name: string; positions?: string[]; is_substitute: boolean; entered_inning?: number; is_helper: boolean }[]
     battingResults?: { batting_order: number; inning: number; at_bat_sequence?: number; hit_result: string; direction: string; rbi_count: number; scored?: boolean; runner_first: boolean; runner_second: boolean; runner_third: boolean; stolen_second: boolean; stolen_third: boolean; stolen_home: boolean }[]
     pitcherResults?: { player_id?: string; player_name: string; innings_outs: number; is_mid_inning_exit: boolean; hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; pitch_count?: number; is_win: boolean; is_lose: boolean; is_save: boolean; is_hold: boolean; is_helper?: boolean }[]
   }) => {
@@ -157,7 +157,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
         slots.get(entry.batting_order)!.entries.push({
           playerId: entry.player_id || "",
           playerName: entry.player_name,
-          position: entry.position as FieldPosition | undefined,
+          positions: (entry.positions ?? []) as FieldPosition[],
           isSubstitute: entry.is_substitute,
           enteredInning: entry.entered_inning,
           isHelper: entry.is_helper,

--- a/components/player-select-dialog.tsx
+++ b/components/player-select-dialog.tsx
@@ -237,13 +237,13 @@ export function PlayerSelectDialog({
 
                 {/* 打・走ボタン（途中出場のみ） */}
                 {entry.isSubstitute && (
-                  <div className="flex gap-2 mb-2">
+                  <div className="grid grid-cols-5 gap-2 mb-2">
                     {SUBSTITUTE_ROLES.map((role) => (
                       <button
                         key={role.value}
                         onClick={() => handlePositionToggle(index, role.value)}
                         className={cn(
-                          "h-10 px-4 rounded-lg font-bold text-sm transition-all",
+                          "h-10 rounded-lg font-bold text-sm transition-all",
                           (entry.positions ?? []).includes(role.value)
                             ? "bg-amber-500 text-white shadow-md scale-105"
                             : "bg-white border border-slate-200 text-slate-600 hover:border-amber-300 hover:bg-amber-50"

--- a/components/player-select-dialog.tsx
+++ b/components/player-select-dialog.tsx
@@ -90,14 +90,12 @@ export function PlayerSelectDialog({
     })
   }
 
-  const handlePositionToggle = (index: number, pos: FieldPosition) => {
+  const handlePositionAdd = (index: number, pos: FieldPosition) => {
     setEntries((prev) => {
       const newEntries = [...prev]
-      const current = newEntries[index].positions ?? []
-      const exists = current.includes(pos)
       newEntries[index] = {
         ...newEntries[index],
-        positions: exists ? current.filter(p => p !== pos) : [...current, pos],
+        positions: [...(newEntries[index].positions ?? []), pos],
       }
       return newEntries
     })
@@ -241,13 +239,8 @@ export function PlayerSelectDialog({
                     {SUBSTITUTE_ROLES.map((role) => (
                       <button
                         key={role.value}
-                        onClick={() => handlePositionToggle(index, role.value)}
-                        className={cn(
-                          "h-10 rounded-lg font-bold text-sm transition-all",
-                          (entry.positions ?? []).includes(role.value)
-                            ? "bg-amber-500 text-white shadow-md scale-105"
-                            : "bg-white border border-slate-200 text-slate-600 hover:border-amber-300 hover:bg-amber-50"
-                        )}
+                        onClick={() => handlePositionAdd(index, role.value)}
+                        className="h-10 rounded-lg font-bold text-sm transition-all bg-white border border-slate-200 text-slate-600 hover:border-amber-300 hover:bg-amber-50"
                       >
                         {role.label}
                       </button>
@@ -260,13 +253,8 @@ export function PlayerSelectDialog({
                   {FIELD_POSITIONS.map((pos) => (
                     <button
                       key={pos.value}
-                      onClick={() => handlePositionToggle(index, pos.value)}
-                      className={cn(
-                        "h-10 rounded-lg font-bold text-sm transition-all",
-                        (entry.positions ?? []).includes(pos.value)
-                          ? "bg-emerald-500 text-white shadow-md scale-105"
-                          : "bg-white border border-slate-200 text-slate-600 hover:border-emerald-300 hover:bg-emerald-50"
-                      )}
+                      onClick={() => handlePositionAdd(index, pos.value)}
+                      className="h-10 rounded-lg font-bold text-sm transition-all bg-white border border-slate-200 text-slate-600 hover:border-emerald-300 hover:bg-emerald-50"
                     >
                       {pos.label}
                     </button>

--- a/components/player-select-dialog.tsx
+++ b/components/player-select-dialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/ui/dialog"
 import { cn } from "@/lib/utils"
 import type { LineupEntry, FieldPosition, Player } from "@/lib/batting-types"
-import { FIELD_POSITIONS } from "@/lib/batting-types"
+import { FIELD_POSITIONS, SUBSTITUTE_ROLES } from "@/lib/batting-types"
 import { sortPlayersByNumber } from "@/lib/sort-utils"
 
 interface PlayerSelectDialogProps {
@@ -36,7 +36,7 @@ export function PlayerSelectDialog({
       if (currentEntries.length > 0) {
         setEntries(currentEntries)
       } else {
-        setEntries([{ playerId: "", playerName: "", position: undefined }])
+        setEntries([{ playerId: "", playerName: "", positions: [] }])
       }
     }
   }, [open, currentEntries])
@@ -83,17 +83,33 @@ export function PlayerSelectDialog({
       newEntries[index] = {
         ...newEntries[index],
         playerName: name,
-        playerId: "", // 手入力の場合はIDをクリア
+        playerId: "",
         isHelper: false,
       }
       return newEntries
     })
   }
 
-  const handlePositionChange = (index: number, position: FieldPosition) => {
+  const handlePositionToggle = (index: number, pos: FieldPosition) => {
     setEntries((prev) => {
       const newEntries = [...prev]
-      newEntries[index] = { ...newEntries[index], position }
+      const current = newEntries[index].positions ?? []
+      const exists = current.includes(pos)
+      newEntries[index] = {
+        ...newEntries[index],
+        positions: exists ? current.filter(p => p !== pos) : [...current, pos],
+      }
+      return newEntries
+    })
+  }
+
+  const handlePositionRemove = (index: number, pos: FieldPosition) => {
+    setEntries((prev) => {
+      const newEntries = [...prev]
+      newEntries[index] = {
+        ...newEntries[index],
+        positions: (newEntries[index].positions ?? []).filter(p => p !== pos),
+      }
       return newEntries
     })
   }
@@ -101,7 +117,7 @@ export function PlayerSelectDialog({
   const handleAddSubstitute = () => {
     setEntries((prev) => [
       ...prev,
-      { playerId: "", playerName: "", position: undefined, isSubstitute: true }
+      { playerId: "", playerName: "", positions: [], isSubstitute: true }
     ])
   }
 
@@ -148,7 +164,7 @@ export function PlayerSelectDialog({
                 </div>
               )}
 
-              {/* 選手名 - 登録済み選手から選択 */}
+              {/* 選手名 */}
               <div>
                 <label className="block text-xs font-semibold text-slate-500 mb-2">
                   選手名
@@ -171,7 +187,6 @@ export function PlayerSelectDialog({
                         </option>
                       ))}
                     </select>
-                    {/* または手入力（助っ人でなく、IDが未選択の場合） */}
                     {!entry.isHelper && !entry.playerId && (
                       <input
                         type="text"
@@ -201,7 +216,6 @@ export function PlayerSelectDialog({
                     />
                   )
                 )}
-                {/* 助っ人トグル（選手選択の下、控えめなデザイン） */}
                 <button
                   onClick={() => entry.isHelper ? handlePlayerSelect(index, "") : handleHelperSelect(index)}
                   className={cn(
@@ -220,14 +234,36 @@ export function PlayerSelectDialog({
                 <label className="block text-xs font-semibold text-slate-500 mb-2">
                   守備位置
                 </label>
+
+                {/* 代打・代走ボタン（途中出場のみ） */}
+                {entry.isSubstitute && (
+                  <div className="flex gap-2 mb-2">
+                    {SUBSTITUTE_ROLES.map((role) => (
+                      <button
+                        key={role.value}
+                        onClick={() => handlePositionToggle(index, role.value)}
+                        className={cn(
+                          "h-10 px-4 rounded-lg font-bold text-sm transition-all",
+                          (entry.positions ?? []).includes(role.value)
+                            ? "bg-amber-500 text-white shadow-md scale-105"
+                            : "bg-white border border-slate-200 text-slate-600 hover:border-amber-300 hover:bg-amber-50"
+                        )}
+                      >
+                        {role.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {/* 守備位置グリッド */}
                 <div className="grid grid-cols-5 gap-2">
                   {FIELD_POSITIONS.map((pos) => (
                     <button
                       key={pos.value}
-                      onClick={() => handlePositionChange(index, pos.value)}
+                      onClick={() => handlePositionToggle(index, pos.value)}
                       className={cn(
                         "h-10 rounded-lg font-bold text-sm transition-all",
-                        entry.position === pos.value
+                        (entry.positions ?? []).includes(pos.value)
                           ? "bg-emerald-500 text-white shadow-md scale-105"
                           : "bg-white border border-slate-200 text-slate-600 hover:border-emerald-300 hover:bg-emerald-50"
                       )}
@@ -236,6 +272,27 @@ export function PlayerSelectDialog({
                     </button>
                   ))}
                 </div>
+
+                {/* 選択済み守備位置チップ */}
+                {(entry.positions ?? []).length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {(entry.positions ?? []).map((pos, posIdx) => (
+                      <span
+                        key={posIdx}
+                        className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-emerald-100 text-emerald-700 text-xs font-bold"
+                      >
+                        {pos}
+                        <button
+                          onClick={() => handlePositionRemove(index, pos)}
+                          className="text-emerald-500 hover:text-emerald-800 leading-none"
+                          aria-label={`${pos}を削除`}
+                        >
+                          ✕
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                )}
               </div>
 
               {/* 途中出場イニング */}

--- a/components/player-select-dialog.tsx
+++ b/components/player-select-dialog.tsx
@@ -153,7 +153,7 @@ export function PlayerSelectDialog({
               {entry.isSubstitute && (
                 <div className="flex items-center justify-between">
                   <span className="text-xs font-semibold text-amber-700 bg-amber-200 px-2 py-1 rounded">
-                    代打・途中出場
+                    打・走・途中出場
                   </span>
                   <button
                     onClick={() => handleRemoveEntry(index)}
@@ -235,7 +235,7 @@ export function PlayerSelectDialog({
                   守備位置
                 </label>
 
-                {/* 代打・代走ボタン（途中出場のみ） */}
+                {/* 打・走ボタン（途中出場のみ） */}
                 {entry.isSubstitute && (
                   <div className="flex gap-2 mb-2">
                     {SUBSTITUTE_ROLES.map((role) => (
@@ -337,7 +337,7 @@ export function PlayerSelectDialog({
               "hover:border-amber-400 hover:text-amber-600 hover:bg-amber-50"
             )}
           >
-            + 代打・途中出場を追加
+            + 途中出場を追加
           </button>
         </div>
 

--- a/lib/batting-types.ts
+++ b/lib/batting-types.ts
@@ -66,8 +66,8 @@ export type FieldPosition =
   | "中"
   | "右"
   | "DH"
-  | "代打"
-  | "代走"
+  | "打"
+  | "走"
 
 export const FIELD_POSITIONS: { value: FieldPosition; label: string }[] = [
   { value: "投", label: "投" },
@@ -83,8 +83,8 @@ export const FIELD_POSITIONS: { value: FieldPosition; label: string }[] = [
 ]
 
 export const SUBSTITUTE_ROLES: { value: FieldPosition; label: string }[] = [
-  { value: "代打", label: "代打" },
-  { value: "代走", label: "代走" },
+  { value: "打", label: "打" },
+  { value: "走", label: "走" },
 ]
 
 // 選手情報

--- a/lib/batting-types.ts
+++ b/lib/batting-types.ts
@@ -55,17 +55,19 @@ export interface CellPosition {
 }
 
 // 守備位置
-export type FieldPosition = 
-  | "投" 
-  | "捕" 
-  | "一" 
-  | "二" 
-  | "三" 
-  | "遊" 
-  | "左" 
-  | "中" 
+export type FieldPosition =
+  | "投"
+  | "捕"
+  | "一"
+  | "二"
+  | "三"
+  | "遊"
+  | "左"
+  | "中"
   | "右"
   | "DH"
+  | "代打"
+  | "代走"
 
 export const FIELD_POSITIONS: { value: FieldPosition; label: string }[] = [
   { value: "投", label: "投" },
@@ -80,6 +82,11 @@ export const FIELD_POSITIONS: { value: FieldPosition; label: string }[] = [
   { value: "DH", label: "DH" },
 ]
 
+export const SUBSTITUTE_ROLES: { value: FieldPosition; label: string }[] = [
+  { value: "代打", label: "代打" },
+  { value: "代走", label: "代走" },
+]
+
 // 選手情報
 export interface Player {
   id: string
@@ -91,7 +98,7 @@ export interface Player {
 export interface LineupEntry {
   playerId: string
   playerName: string
-  position?: FieldPosition
+  positions?: FieldPosition[]  // 守備位置（順番通りの配列）
   isSubstitute?: boolean  // 代打・途中出場
   enteredInning?: number  // 何回から出場したか
   isHelper?: boolean      // 助っ人（個人成績に含めない）

--- a/scripts/005_add_positions_to_lineup_entries.sql
+++ b/scripts/005_add_positions_to_lineup_entries.sql
@@ -1,0 +1,3 @@
+ALTER TABLE lineup_entries ADD COLUMN IF NOT EXISTS positions TEXT[];
+UPDATE lineup_entries SET positions = ARRAY[position] WHERE position IS NOT NULL;
+ALTER TABLE lineup_entries DROP COLUMN IF EXISTS position;


### PR DESCRIPTION
- lineup_entries.position を positions TEXT[] に変更するマイグレーション追加
- FieldPosition 型に代打・代走を追加
- LineupEntry.position を positions[] 配列に変更
- PlayerSelectDialog: 守備位置マルチ選択UI（順番通りチップ表示・✕削除）
- 途中出場選手欄に代打・代走ボタンを追加
- BattingGrid: 守備列を「first+」表記に変更
- 試合結果画面: 守備列に全ポジション横並び表示

https://claude.ai/code/session_013k1qd8Fz918TMwsDq9RhUK