### PR TITLE
Refactor pitcher award fields from boolean to single enum column

### DIFF
--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -492,6 +492,7 @@ export default function GameDetailPage() {
               <table className="w-full text-center text-sm">
                 <thead>
                   <tr className="border-b bg-slate-50">
+                    <th className="px-2 py-2"></th>
                     <th className="px-2 py-2 text-left">投手</th>
                     <th className="px-2 py-2">投球回</th>
                     <th className="px-2 py-2">被安打</th>
@@ -499,12 +500,17 @@ export default function GameDetailPage() {
                     <th className="px-2 py-2">四球</th>
                     <th className="px-2 py-2">失点</th>
                     <th className="px-2 py-2">自責</th>
-                    <th className="px-2 py-2">記録</th>
                   </tr>
                 </thead>
                 <tbody>
                   {pitcherResults.map((pitcher, index) => (
                     <tr key={index} className="border-b">
+                      <td className="px-2 py-2">
+                        {pitcher.pitcher_award === 'win'  && <span className="rounded bg-blue-100 px-1 text-blue-700">勝</span>}
+                        {pitcher.pitcher_award === 'lose' && <span className="rounded bg-red-100 px-1 text-red-700">敗</span>}
+                        {pitcher.pitcher_award === 'save' && <span className="rounded bg-green-100 px-1 text-green-700">S</span>}
+                        {pitcher.pitcher_award === 'hold' && <span className="rounded bg-purple-100 px-1 text-purple-700">H</span>}
+                      </td>
                       <td className="px-2 py-2 text-left font-medium">{pitcher.player_name}</td>
                       <td className="px-2 py-2">{formatInnings(pitcher.innings_outs, pitcher.is_mid_inning_exit)}</td>
                       <td className="px-2 py-2">{pitcher.hits}</td>
@@ -512,12 +518,6 @@ export default function GameDetailPage() {
                       <td className="px-2 py-2">{pitcher.walks}</td>
                       <td className="px-2 py-2">{pitcher.runs}</td>
                       <td className="px-2 py-2">{pitcher.earned_runs}</td>
-                      <td className="px-2 py-2">
-                        {pitcher.pitcher_award === 'win'  && <span className="rounded bg-blue-100 px-1 text-blue-700">勝</span>}
-                        {pitcher.pitcher_award === 'lose' && <span className="rounded bg-red-100 px-1 text-red-700">敗</span>}
-                        {pitcher.pitcher_award === 'save' && <span className="rounded bg-green-100 px-1 text-green-700">S</span>}
-                        {pitcher.pitcher_award === 'hold' && <span className="rounded bg-purple-100 px-1 text-purple-700">H</span>}
-                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -52,10 +52,7 @@ interface GameDetail {
     walks: number
     hit_by_pitch: number
     home_runs: number
-    is_win: boolean
-    is_lose: boolean
-    is_save: boolean
-    is_hold: boolean
+    pitcher_award: string | null
   }>
 }
 
@@ -516,10 +513,10 @@ export default function GameDetailPage() {
                       <td className="px-2 py-2">{pitcher.runs}</td>
                       <td className="px-2 py-2">{pitcher.earned_runs}</td>
                       <td className="px-2 py-2">
-                        {pitcher.is_win && <span className="rounded bg-blue-100 px-1 text-blue-700">勝</span>}
-                        {pitcher.is_lose && <span className="rounded bg-red-100 px-1 text-red-700">敗</span>}
-                        {pitcher.is_save && <span className="rounded bg-green-100 px-1 text-green-700">S</span>}
-                        {pitcher.is_hold && <span className="rounded bg-purple-100 px-1 text-purple-700">H</span>}
+                        {pitcher.pitcher_award === 'win'  && <span className="rounded bg-blue-100 px-1 text-blue-700">勝</span>}
+                        {pitcher.pitcher_award === 'lose' && <span className="rounded bg-red-100 px-1 text-red-700">敗</span>}
+                        {pitcher.pitcher_award === 'save' && <span className="rounded bg-green-100 px-1 text-green-700">S</span>}
+                        {pitcher.pitcher_award === 'hold' && <span className="rounded bg-purple-100 px-1 text-purple-700">H</span>}
                       </td>
                     </tr>
                   ))}

--- a/app/api/games/[id]/pitchers/route.ts
+++ b/app/api/games/[id]/pitchers/route.ts
@@ -15,10 +15,7 @@ interface PitcherResult {
   hitByPitch: number
   homeRuns: number
   pitchCount?: number
-  isWin?: boolean
-  isLose?: boolean
-  isSave?: boolean
-  isHold?: boolean
+  award?: string | null
   isHelper?: boolean
 }
 
@@ -67,10 +64,7 @@ export async function POST(
         hit_by_pitch: p.hitByPitch || 0,
         home_runs: p.homeRuns || 0,
         pitch_count: p.pitchCount || null,
-        is_win: p.isWin || false,
-        is_lose: p.isLose || false,
-        is_save: p.isSave || false,
-        is_hold: p.isHold || false,
+        pitcher_award: p.award ?? null,
         is_helper: p.isHelper || false,
         order_index: index,
       }))

--- a/app/api/games/[id]/route.ts
+++ b/app/api/games/[id]/route.ts
@@ -238,10 +238,7 @@ export async function PUT(
       hitByPitch: number
       homeRuns: number
       pitchCount?: number
-      isWin?: boolean
-      isLose?: boolean
-      isSave?: boolean
-      isHold?: boolean
+      award?: string | null
       isHelper?: boolean
     }, index: number) => ({
       game_id: id,
@@ -257,10 +254,7 @@ export async function PUT(
       hit_by_pitch: p.hitByPitch,
       home_runs: p.homeRuns,
       pitch_count: p.pitchCount || null,
-      is_win: p.isWin || false,
-      is_lose: p.isLose || false,
-      is_save: p.isSave || false,
-      is_hold: p.isHold || false,
+      pitcher_award: p.award ?? null,
       is_helper: p.isHelper || false,
       order_index: index,
     }))

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -175,10 +175,7 @@ export async function POST(request: Request) {
         hitByPitch: number
         homeRuns: number
         pitchCount?: number
-        isWin?: boolean
-        isLose?: boolean
-        isSave?: boolean
-        isHold?: boolean
+        award?: string | null
         isHelper?: boolean
       }, index: number) => ({
         game_id: gameId,
@@ -194,10 +191,7 @@ export async function POST(request: Request) {
         hit_by_pitch: p.hitByPitch || 0,
         home_runs: p.homeRuns || 0,
         pitch_count: p.pitchCount || null,
-        is_win: p.isWin || false,
-        is_lose: p.isLose || false,
-        is_save: p.isSave || false,
-        is_hold: p.isHold || false,
+        pitcher_award: p.award ?? null,
         is_helper: p.isHelper || false,
         order_index: index,
       }))

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -153,10 +153,7 @@ export async function GET(request: Request) {
       walks: number
       hit_by_pitch: number
       home_runs: number
-      is_win: boolean
-      is_lose: boolean
-      is_save: boolean
-      is_hold: boolean
+      pitcher_award: string | null
     }>
   }>()
 
@@ -183,10 +180,7 @@ export async function GET(request: Request) {
       walks: result.walks || 0,
       hit_by_pitch: result.hit_by_pitch || 0,
       home_runs: result.home_runs || 0,
-      is_win: result.is_win || false,
-      is_lose: result.is_lose || false,
-      is_save: result.is_save || false,
-      is_hold: result.is_hold || false,
+      pitcher_award: result.pitcher_award ?? null,
     })
   }
 

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -120,7 +120,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
     inningScores?: { inning: number; our_score: number; opponent_score: number }[]
     lineupEntries?: { batting_order: number; player_id: string; player_name: string; position: string; is_substitute: boolean; entered_inning?: number; is_helper: boolean }[]
     battingResults?: { batting_order: number; inning: number; at_bat_sequence?: number; hit_result: string; direction: string; rbi_count: number; scored?: boolean; runner_first: boolean; runner_second: boolean; runner_third: boolean; stolen_second: boolean; stolen_third: boolean; stolen_home: boolean }[]
-    pitcherResults?: { player_id?: string; player_name: string; innings_outs: number; is_mid_inning_exit: boolean; hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; pitch_count?: number; is_win: boolean; is_lose: boolean; is_save: boolean; is_hold: boolean; is_helper?: boolean }[]
+    pitcherResults?: { player_id?: string; player_name: string; innings_outs: number; is_mid_inning_exit: boolean; hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; pitch_count?: number; pitcher_award?: string | null; is_helper?: boolean }[]
   }) => {
     if (gameData.game) {
       setGameDate(gameData.game.date || "")
@@ -215,10 +215,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
         hitByPitch: p.hit_by_pitch,
         homeRuns: p.home_runs,
         pitchCount: p.pitch_count,
-        isWin: p.is_win,
-        isLose: p.is_lose,
-        isSave: p.is_save,
-        isHold: p.is_hold,
+        award: p.pitcher_award ?? null,
         isHelper: p.is_helper || false,
       })))
     }

--- a/components/pitcher-input.tsx
+++ b/components/pitcher-input.tsx
@@ -182,6 +182,7 @@ export function PitcherInput({
           <table className="w-full min-w-[560px] text-sm">
             <thead className="bg-slate-50 text-slate-600">
               <tr>
+                <th className="px-2 py-2 text-center font-medium"></th>
                 <th className="px-3 py-2 text-left font-medium">投手</th>
                 <th className="px-2 py-2 text-center font-medium">回</th>
                 <th className="px-2 py-2 text-center font-medium">被安</th>
@@ -191,7 +192,6 @@ export function PitcherInput({
                 <th className="px-2 py-2 text-center font-medium">四球</th>
                 <th className="px-2 py-2 text-center font-medium">死球</th>
                 <th className="px-2 py-2 text-center font-medium">被本</th>
-                <th className="px-2 py-2 text-center font-medium">決着</th>
                 <th className="px-2 py-2 text-center font-medium"></th>
               </tr>
             </thead>
@@ -202,6 +202,14 @@ export function PitcherInput({
                   className="hover:bg-slate-50 cursor-pointer transition-colors"
                   onClick={() => handleEdit(index)}
                 >
+                  <td className="px-2 py-2 text-center">
+                    <div className="flex items-center justify-center gap-1">
+                      {pitcher.award === 'win'  && <span className="text-amber-500 font-bold">勝</span>}
+                      {pitcher.award === 'lose' && <span className="text-slate-500 font-bold">敗</span>}
+                      {pitcher.award === 'save' && <span className="text-blue-500 font-bold">S</span>}
+                      {pitcher.award === 'hold' && <span className="text-emerald-500 font-bold">H</span>}
+                    </div>
+                  </td>
                   <td className="px-3 py-2 font-medium text-slate-800">
                     <div className="flex items-center gap-1.5">
                       {pitcher.playerName}
@@ -218,14 +226,6 @@ export function PitcherInput({
                   <td className="px-2 py-2 text-center">{pitcher.walks}</td>
                   <td className="px-2 py-2 text-center">{pitcher.hitByPitch}</td>
                   <td className="px-2 py-2 text-center">{pitcher.homeRuns}</td>
-                  <td className="px-2 py-2 text-center">
-                    <div className="flex items-center justify-center gap-1">
-                      {pitcher.award === 'win'  && <span className="text-amber-500 font-bold">W</span>}
-                      {pitcher.award === 'lose' && <span className="text-slate-500 font-bold">L</span>}
-                      {pitcher.award === 'save' && <span className="text-blue-500 font-bold">S</span>}
-                      {pitcher.award === 'hold' && <span className="text-emerald-500 font-bold">H</span>}
-                    </div>
-                  </td>
                   <td className="px-2 py-2 text-center" onClick={(e) => e.stopPropagation()}>
                     <button
                       onClick={() => handleDelete(index)}

--- a/components/pitcher-input.tsx
+++ b/components/pitcher-input.tsx
@@ -220,10 +220,10 @@ export function PitcherInput({
                   <td className="px-2 py-2 text-center">{pitcher.homeRuns}</td>
                   <td className="px-2 py-2 text-center">
                     <div className="flex items-center justify-center gap-1">
-                      {pitcher.isWin && <span className="text-amber-500 font-bold">W</span>}
-                      {pitcher.isLose && <span className="text-slate-500 font-bold">L</span>}
-                      {pitcher.isSave && <span className="text-blue-500 font-bold">S</span>}
-                      {pitcher.isHold && <span className="text-emerald-500 font-bold">H</span>}
+                      {pitcher.award === 'win'  && <span className="text-amber-500 font-bold">W</span>}
+                      {pitcher.award === 'lose' && <span className="text-slate-500 font-bold">L</span>}
+                      {pitcher.award === 'save' && <span className="text-blue-500 font-bold">S</span>}
+                      {pitcher.award === 'hold' && <span className="text-emerald-500 font-bold">H</span>}
                     </div>
                   </td>
                   <td className="px-2 py-2 text-center" onClick={(e) => e.stopPropagation()}>
@@ -379,29 +379,29 @@ export function PitcherInput({
                 <DecisionButton
                   label="勝利"
                   icon={Trophy}
-                  active={form.isWin}
-                  onClick={() => setForm({ ...form, isWin: !form.isWin, isLose: false })}
+                  active={form.award === 'win'}
+                  onClick={() => setForm({ ...form, award: form.award === 'win' ? null : 'win' })}
                   color="bg-amber-500"
                 />
                 <DecisionButton
                   label="敗戦"
                   icon={ThumbsDown}
-                  active={form.isLose}
-                  onClick={() => setForm({ ...form, isLose: !form.isLose, isWin: false })}
+                  active={form.award === 'lose'}
+                  onClick={() => setForm({ ...form, award: form.award === 'lose' ? null : 'lose' })}
                   color="bg-slate-500"
                 />
                 <DecisionButton
                   label="セーブ"
                   icon={Shield}
-                  active={form.isSave}
-                  onClick={() => setForm({ ...form, isSave: !form.isSave })}
+                  active={form.award === 'save'}
+                  onClick={() => setForm({ ...form, award: form.award === 'save' ? null : 'save' })}
                   color="bg-blue-500"
                 />
                 <DecisionButton
                   label="ホールド"
                   icon={Star}
-                  active={form.isHold}
-                  onClick={() => setForm({ ...form, isHold: !form.isHold })}
+                  active={form.award === 'hold'}
+                  onClick={() => setForm({ ...form, award: form.award === 'hold' ? null : 'hold' })}
                   color="bg-emerald-500"
                 />
               </div>

--- a/lib/batting-types.ts
+++ b/lib/batting-types.ts
@@ -109,6 +109,8 @@ export interface InningScore {
   opponent: number
 }
 
+export type PitcherAward = 'win' | 'lose' | 'save' | 'hold'
+
 // 投手成績
 export interface PitcherResult {
   playerId: string
@@ -123,10 +125,7 @@ export interface PitcherResult {
   hitByPitch: number          // 与死球
   homeRuns: number            // 被本塁打
   pitchCount?: number         // 球数
-  isWin?: boolean             // 勝利
-  isLose?: boolean            // 敗戦
-  isSave?: boolean            // セーブ
-  isHold?: boolean            // ホールド
+  award?: PitcherAward | null // 勝利・敗戦・セーブ・ホールド（排他）
   isHelper?: boolean          // 助っ人（個人成績に含めない）
 }
 

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -189,10 +189,7 @@ export function calculatePitchingStats(
     walks: number
     hit_by_pitch: number
     home_runs: number
-    is_win: boolean
-    is_lose: boolean
-    is_save: boolean
-    is_hold: boolean
+    pitcher_award: string | null
   }>
 ): PitchingStats {
   const stats: PitchingStats = {
@@ -217,10 +214,10 @@ export function calculatePitchingStats(
   }
 
   for (const result of pitcherResults) {
-    if (result.is_win) stats.wins++
-    if (result.is_lose) stats.losses++
-    if (result.is_save) stats.saves++
-    if (result.is_hold) stats.holds++
+    if (result.pitcher_award === 'win')  stats.wins++
+    if (result.pitcher_award === 'lose') stats.losses++
+    if (result.pitcher_award === 'save') stats.saves++
+    if (result.pitcher_award === 'hold') stats.holds++
     stats.totalOuts += result.outs_pitched || 0
     stats.hits += result.hits || 0
     stats.runs += result.runs || 0

--- a/scripts/005_pitcher_award.sql
+++ b/scripts/005_pitcher_award.sql
@@ -1,0 +1,12 @@
+-- pitcher_results の勝敗フィールドを4列から1列に統合
+ALTER TABLE pitcher_results ADD COLUMN IF NOT EXISTS pitcher_award TEXT;
+
+UPDATE pitcher_results SET pitcher_award = 'win'  WHERE is_win  = true;
+UPDATE pitcher_results SET pitcher_award = 'lose' WHERE is_lose = true;
+UPDATE pitcher_results SET pitcher_award = 'save' WHERE is_save = true;
+UPDATE pitcher_results SET pitcher_award = 'hold' WHERE is_hold = true;
+
+ALTER TABLE pitcher_results DROP COLUMN IF EXISTS is_win;
+ALTER TABLE pitcher_results DROP COLUMN IF EXISTS is_lose;
+ALTER TABLE pitcher_results DROP COLUMN IF EXISTS is_save;
+ALTER TABLE pitcher_results DROP COLUMN IF EXISTS is_hold;


### PR DESCRIPTION
## Summary
Consolidates pitcher award tracking from four separate boolean columns (`is_win`, `is_lose`, `is_save`, `is_hold`) into a single nullable enum column (`pitcher_award`). This simplifies the data model and enforces mutual exclusivity at the database level.

## Key Changes

- **Database Schema**: Added migration script to consolidate four boolean columns into a single `pitcher_award` TEXT column with values: 'win', 'lose', 'save', 'hold', or null
- **Type Definitions**: Updated `PitcherResult` interface to use `award?: PitcherAward | null` instead of four separate boolean fields; added new `PitcherAward` type union
- **API Routes**: Updated all pitcher result endpoints (`/api/games`, `/api/games/[id]`, `/api/games/[id]/pitchers`, `/api/stats`) to map between the new single column format and internal representations
- **UI Components**: 
  - Refactored `PitcherInput` component to use `form.award` instead of individual boolean flags
  - Updated decision buttons to toggle award state with mutual exclusivity logic
  - Moved award display column to the first position in pitcher tables for better visibility
- **Stats Calculation**: Updated `calculatePitchingStats` to check `pitcher_award` enum values instead of individual boolean fields
- **Game Editor**: Updated data transformation logic to map between `pitcher_award` and the internal `award` field

## Implementation Details

- Award state is now mutually exclusive by design (only one award per pitcher per game)
- The UI maintains the same visual appearance with color-coded badges (amber for win, slate for loss, blue for save, emerald for hold)
- All existing functionality is preserved while reducing code complexity and database columns

https://claude.ai/code/session_01XsMbk23jNir7udvCzekMKd