### PR TITLE
Add batters faced tracking to pitcher statistics

### DIFF
--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -52,6 +52,7 @@ interface GameDetail {
     walks: number
     hit_by_pitch: number
     home_runs: number
+    batters_faced?: number
     pitcher_award: string | null
   }>
 }
@@ -503,9 +504,12 @@ export default function GameDetailPage() {
                     <th className="px-2 py-2"></th>
                     <th className="px-2 py-2 text-left">投手</th>
                     <th className="px-2 py-2">投球回</th>
-                    <th className="px-2 py-2">被安打</th>
-                    <th className="px-2 py-2">奪三振</th>
+                    <th className="px-2 py-2">打者</th>
+                    <th className="px-2 py-2">被安</th>
+                    <th className="px-2 py-2">被本</th>
+                    <th className="px-2 py-2">三振</th>
                     <th className="px-2 py-2">四球</th>
+                    <th className="px-2 py-2">死球</th>
                     <th className="px-2 py-2">失点</th>
                     <th className="px-2 py-2">自責</th>
                   </tr>
@@ -521,9 +525,12 @@ export default function GameDetailPage() {
                       </td>
                       <td className="px-2 py-2 text-left font-medium">{pitcher.player_name}</td>
                       <td className="px-2 py-2">{formatInnings(pitcher.innings_outs, pitcher.is_mid_inning_exit)}</td>
+                      <td className="px-2 py-2">{pitcher.batters_faced ?? 0}</td>
                       <td className="px-2 py-2">{pitcher.hits}</td>
+                      <td className="px-2 py-2">{pitcher.home_runs}</td>
                       <td className="px-2 py-2">{pitcher.strikeouts}</td>
                       <td className="px-2 py-2">{pitcher.walks}</td>
+                      <td className="px-2 py-2">{pitcher.hit_by_pitch}</td>
                       <td className="px-2 py-2">{pitcher.runs}</td>
                       <td className="px-2 py-2">{pitcher.earned_runs}</td>
                     </tr>

--- a/app/[teamId]/stats/page.tsx
+++ b/app/[teamId]/stats/page.tsx
@@ -68,6 +68,7 @@ const PITCHING_COLUMNS: Array<{
     const rem = v % 3
     return rem === 0 ? `${whole}` : `${whole} ${rem}/3`
   }, primary: true },
+  { key: "battersFaced", label: "打者", shortLabel: "打者", format: (v) => v.toString() },
   { key: "hits", label: "被安打", shortLabel: "被安", format: (v) => v.toString() },
   { key: "runs", label: "失点", shortLabel: "失", format: (v) => v.toString() },
   { key: "earnedRuns", label: "自責", shortLabel: "自", format: (v) => v.toString(), primary: true },

--- a/app/api/games/[id]/pitchers/route.ts
+++ b/app/api/games/[id]/pitchers/route.ts
@@ -14,6 +14,7 @@ interface PitcherResult {
   walks: number
   hitByPitch: number
   homeRuns: number
+  battersFaced?: number
   pitchCount?: number
   isWin?: boolean
   isLose?: boolean
@@ -66,6 +67,7 @@ export async function POST(
         walks: p.walks || 0,
         hit_by_pitch: p.hitByPitch || 0,
         home_runs: p.homeRuns || 0,
+        batters_faced: p.battersFaced || 0,
         pitch_count: p.pitchCount || null,
         is_win: p.isWin || false,
         is_lose: p.isLose || false,

--- a/app/api/games/[id]/route.ts
+++ b/app/api/games/[id]/route.ts
@@ -237,6 +237,7 @@ export async function PUT(
       walks: number
       hitByPitch: number
       homeRuns: number
+      battersFaced?: number
       pitchCount?: number
       isWin?: boolean
       isLose?: boolean
@@ -256,6 +257,7 @@ export async function PUT(
       walks: p.walks,
       hit_by_pitch: p.hitByPitch,
       home_runs: p.homeRuns,
+      batters_faced: p.battersFaced || 0,
       pitch_count: p.pitchCount || null,
       is_win: p.isWin || false,
       is_lose: p.isLose || false,

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -153,6 +153,7 @@ export async function GET(request: Request) {
       walks: number
       hit_by_pitch: number
       home_runs: number
+      batters_faced: number
       is_win: boolean
       is_lose: boolean
       is_save: boolean
@@ -183,6 +184,7 @@ export async function GET(request: Request) {
       walks: result.walks || 0,
       hit_by_pitch: result.hit_by_pitch || 0,
       home_runs: result.home_runs || 0,
+      batters_faced: result.batters_faced || 0,
       is_win: result.is_win || false,
       is_lose: result.is_lose || false,
       is_save: result.is_save || false,

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -120,7 +120,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
     inningScores?: { inning: number; our_score: number; opponent_score: number }[]
     lineupEntries?: { batting_order: number; player_id: string; player_name: string; position: string; is_substitute: boolean; entered_inning?: number; is_helper: boolean }[]
     battingResults?: { batting_order: number; inning: number; at_bat_sequence?: number; hit_result: string; direction: string; rbi_count: number; scored?: boolean; runner_first: boolean; runner_second: boolean; runner_third: boolean; stolen_second: boolean; stolen_third: boolean; stolen_home: boolean }[]
-    pitcherResults?: { player_id?: string; player_name: string; innings_outs: number; is_mid_inning_exit: boolean; hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; pitch_count?: number; is_win: boolean; is_lose: boolean; is_save: boolean; is_hold: boolean; is_helper?: boolean }[]
+    pitcherResults?: { player_id?: string; player_name: string; innings_outs: number; is_mid_inning_exit: boolean; hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; batters_faced?: number; pitch_count?: number; is_win: boolean; is_lose: boolean; is_save: boolean; is_hold: boolean; is_helper?: boolean }[]
   }) => {
     if (gameData.game) {
       setGameDate(gameData.game.date || "")
@@ -214,6 +214,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack }: Game
         walks: p.walks,
         hitByPitch: p.hit_by_pitch,
         homeRuns: p.home_runs,
+        battersFaced: p.batters_faced || 0,
         pitchCount: p.pitch_count,
         isWin: p.is_win,
         isLose: p.is_lose,

--- a/components/pitcher-input.tsx
+++ b/components/pitcher-input.tsx
@@ -189,12 +189,12 @@ export function PitcherInput({
                 <th className="px-2 py-2 text-center font-medium">回</th>
                 <th className="px-2 py-2 text-center font-medium">打者</th>
                 <th className="px-2 py-2 text-center font-medium">被安</th>
-                <th className="px-2 py-2 text-center font-medium">失点</th>
-                <th className="px-2 py-2 text-center font-medium">自責</th>
-                <th className="px-2 py-2 text-center font-medium">奪三</th>
+                <th className="px-2 py-2 text-center font-medium">被本</th>
+                <th className="px-2 py-2 text-center font-medium">三振</th>
                 <th className="px-2 py-2 text-center font-medium">四球</th>
                 <th className="px-2 py-2 text-center font-medium">死球</th>
-                <th className="px-2 py-2 text-center font-medium">被本</th>
+                <th className="px-2 py-2 text-center font-medium">失点</th>
+                <th className="px-2 py-2 text-center font-medium">自責</th>
                 <th className="px-2 py-2 text-center font-medium"></th>
               </tr>
             </thead>
@@ -224,12 +224,12 @@ export function PitcherInput({
                   <td className="px-2 py-2 text-center">{formatInnings(pitcher.outsPitched, pitcher.isMidInningExit)}</td>
                   <td className="px-2 py-2 text-center">{pitcher.battersFaced ?? 0}</td>
                   <td className="px-2 py-2 text-center">{pitcher.hits}</td>
-                  <td className="px-2 py-2 text-center">{pitcher.runs}</td>
-                  <td className="px-2 py-2 text-center">{pitcher.earnedRuns}</td>
+                  <td className="px-2 py-2 text-center">{pitcher.homeRuns}</td>
                   <td className="px-2 py-2 text-center">{pitcher.strikeouts}</td>
                   <td className="px-2 py-2 text-center">{pitcher.walks}</td>
                   <td className="px-2 py-2 text-center">{pitcher.hitByPitch}</td>
-                  <td className="px-2 py-2 text-center">{pitcher.homeRuns}</td>
+                  <td className="px-2 py-2 text-center">{pitcher.runs}</td>
+                  <td className="px-2 py-2 text-center">{pitcher.earnedRuns}</td>
                   <td className="px-2 py-2 text-center" onClick={(e) => e.stopPropagation()}>
                     <button
                       onClick={() => handleDelete(index)}
@@ -339,9 +339,19 @@ export function PitcherInput({
             <div className="bg-slate-50 rounded-xl p-4">
               <div className="grid grid-cols-1 gap-y-3 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-4">
                 <StatButton
+                  label="打者"
+                  value={form.battersFaced ?? 0}
+                  onChange={(v) => setForm({ ...form, battersFaced: v })}
+                />
+                <StatButton
                   label="被安打"
                   value={form.hits}
                   onChange={(v) => setForm({ ...form, hits: v })}
+                />
+                <StatButton
+                  label="被本塁打"
+                  value={form.homeRuns}
+                  onChange={(v) => setForm({ ...form, homeRuns: v })}
                 />
                 <StatButton
                   label="奪三振"
@@ -367,16 +377,6 @@ export function PitcherInput({
                   label="自責点"
                   value={form.earnedRuns}
                   onChange={(v) => setForm({ ...form, earnedRuns: v })}
-                />
-                <StatButton
-                  label="被本塁打"
-                  value={form.homeRuns}
-                  onChange={(v) => setForm({ ...form, homeRuns: v })}
-                />
-                <StatButton
-                  label="打者"
-                  value={form.battersFaced ?? 0}
-                  onChange={(v) => setForm({ ...form, battersFaced: v })}
                 />
               </div>
             </div>

--- a/components/pitcher-input.tsx
+++ b/components/pitcher-input.tsx
@@ -55,6 +55,7 @@ export function PitcherInput({
     walks: 0,
     hitByPitch: 0,
     homeRuns: 0,
+    battersFaced: 0,
   })
 
   const handleAdd = () => {
@@ -71,6 +72,7 @@ export function PitcherInput({
       walks: 0,
       hitByPitch: 0,
       homeRuns: 0,
+      battersFaced: 0,
       isHelper: false,
     })
     setIsDialogOpen(true)
@@ -184,6 +186,7 @@ export function PitcherInput({
               <tr>
                 <th className="px-3 py-2 text-left font-medium">投手</th>
                 <th className="px-2 py-2 text-center font-medium">回</th>
+                <th className="px-2 py-2 text-center font-medium">打者</th>
                 <th className="px-2 py-2 text-center font-medium">被安</th>
                 <th className="px-2 py-2 text-center font-medium">失点</th>
                 <th className="px-2 py-2 text-center font-medium">自責</th>
@@ -211,6 +214,7 @@ export function PitcherInput({
                     </div>
                   </td>
                   <td className="px-2 py-2 text-center">{formatInnings(pitcher.outsPitched, pitcher.isMidInningExit)}</td>
+                  <td className="px-2 py-2 text-center">{pitcher.battersFaced ?? 0}</td>
                   <td className="px-2 py-2 text-center">{pitcher.hits}</td>
                   <td className="px-2 py-2 text-center">{pitcher.runs}</td>
                   <td className="px-2 py-2 text-center">{pitcher.earnedRuns}</td>
@@ -368,6 +372,11 @@ export function PitcherInput({
                   label="被本塁打"
                   value={form.homeRuns}
                   onChange={(v) => setForm({ ...form, homeRuns: v })}
+                />
+                <StatButton
+                  label="打者"
+                  value={form.battersFaced ?? 0}
+                  onChange={(v) => setForm({ ...form, battersFaced: v })}
                 />
               </div>
             </div>

--- a/lib/batting-types.ts
+++ b/lib/batting-types.ts
@@ -122,6 +122,7 @@ export interface PitcherResult {
   walks: number               // 与四球
   hitByPitch: number          // 与死球
   homeRuns: number            // 被本塁打
+  battersFaced?: number       // 対戦打者数
   pitchCount?: number         // 球数
   isWin?: boolean             // 勝利
   isLose?: boolean            // 敗戦

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -168,6 +168,7 @@ export interface PitchingStats {
   walks: number              // 与四球
   hitByPitch: number         // 与死球
   homeRuns: number           // 被本塁打
+  battersFaced: number       // 対戦打者数
 
   // 計算指標
   era: number                // 防御率
@@ -189,6 +190,7 @@ export function calculatePitchingStats(
     walks: number
     hit_by_pitch: number
     home_runs: number
+    batters_faced: number
     is_win: boolean
     is_lose: boolean
     is_save: boolean
@@ -210,6 +212,7 @@ export function calculatePitchingStats(
     walks: 0,
     hitByPitch: 0,
     homeRuns: 0,
+    battersFaced: 0,
     era: 0,
     whip: 0,
     strikeoutRate: 0,
@@ -229,6 +232,7 @@ export function calculatePitchingStats(
     stats.walks += result.walks || 0
     stats.hitByPitch += result.hit_by_pitch || 0
     stats.homeRuns += result.home_runs || 0
+    stats.battersFaced += result.batters_faced || 0
   }
 
   stats.inningsPitched = stats.totalOuts / 3

--- a/scripts/005_add_batters_faced.sql
+++ b/scripts/005_add_batters_faced.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pitcher_results ADD COLUMN batters_faced INTEGER DEFAULT 0;


### PR DESCRIPTION
## Summary
This PR adds support for tracking the number of batters faced by pitchers across the application. This metric is important for baseball statistics and analytics.

## Key Changes

- **Data Model Updates**
  - Added `battersFaced` field to `PitchingStats` interface in `lib/stats.ts`
  - Added `battersFaced` property to `PitcherResult` interface in `lib/batting-types.ts`
  - Added database migration to create `batters_faced` column in `pitcher_results` table

- **UI Components**
  - Updated pitcher input form to include "打者" (batters faced) field in the stats section
  - Reordered pitcher statistics display for better logical flow (batters faced now appears before hits)
  - Updated pitcher statistics table headers and data columns in game detail page to display batters faced

- **API & Data Processing**
  - Updated pitcher result endpoints (`POST` and `PUT` in `app/api/games/[id]/route.ts` and `app/api/games/[id]/pitchers/route.ts`) to handle `batters_faced` field
  - Updated stats calculation API (`app/api/stats/route.ts`) to aggregate batters faced across pitcher results
  - Modified `calculatePitchingStats()` function to accumulate batters faced values

- **Stats Display**
  - Added "打者" column to pitching statistics table in stats page (`app/[teamId]/stats/page.tsx`)
  - Updated game editor to properly map `batters_faced` from API responses

## Implementation Details
- The `battersFaced` field is initialized to 0 for new pitcher entries
- The field is properly persisted through the database and API layers
- Statistics are aggregated correctly when calculating cumulative pitcher stats
- UI displays the metric consistently across all pitcher-related views

https://claude.ai/code/session_01HdmnwiypdEu5e7SzUkHCaP