### PR TITLE
Add footer component and integrate into team layout

### DIFF
--- a/app/[teamId]/layout.tsx
+++ b/app/[teamId]/layout.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 import { AppHeader } from "@/components/app-header"
+import { AppFooter } from "@/components/app-footer"
 
 interface Props {
   children: React.ReactNode
@@ -22,9 +23,10 @@ export default async function TeamLayout({ children, params }: Props) {
   }
 
   return (
-    <>
+    <div className="flex min-h-screen flex-col">
       <AppHeader teamName={data.name} />
-      {children}
-    </>
+      <div className="flex-1">{children}</div>
+      <AppFooter />
+    </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -120,6 +120,16 @@ export default function LandingPage() {
       <footer className="border-t border-slate-700 py-8">
         <div className="mx-auto max-w-6xl px-4 text-center text-sm text-slate-500">
           <p>{APP_NAME} - チームの記録を管理するアプリ</p>
+          <p className="mt-2">
+            <a
+              href="https://forms.gle/wPRQDXBgRxCD5JqPA"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-slate-300 transition-colors"
+            >
+              問い合わせ
+            </a>
+          </p>
         </div>
       </footer>
     </main>

--- a/components/app-footer.tsx
+++ b/components/app-footer.tsx
@@ -1,0 +1,16 @@
+export function AppFooter() {
+  return (
+    <footer className="border-t border-border py-4 mt-auto">
+      <div className="mx-auto max-w-6xl px-4 text-center text-xs text-muted-foreground">
+        <a
+          href="https://forms.gle/wPRQDXBgRxCD5JqPA"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-foreground transition-colors"
+        >
+          問い合わせ
+        </a>
+      </div>
+    </footer>
+  )
+}

--- a/components/app-footer.tsx
+++ b/components/app-footer.tsx
@@ -1,15 +1,20 @@
+import { APP_NAME } from "@/lib/constants"
+
 export function AppFooter() {
   return (
-    <footer className="border-t border-border py-4 mt-auto">
-      <div className="mx-auto max-w-6xl px-4 text-center text-xs text-muted-foreground">
-        <a
-          href="https://forms.gle/wPRQDXBgRxCD5JqPA"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-foreground transition-colors"
-        >
-          問い合わせ
-        </a>
+    <footer className="border-t border-slate-200 py-4 mt-auto">
+      <div className="mx-auto max-w-6xl px-4 text-center text-xs text-slate-400">
+        <p>{APP_NAME} - チームの記録を管理するアプリ</p>
+        <p className="mt-1">
+          <a
+            href="https://forms.gle/wPRQDXBgRxCD5JqPA"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-slate-600 transition-colors"
+          >
+            問い合わせ
+          </a>
+        </p>
       </div>
     </footer>
   )


### PR DESCRIPTION
## Summary
This PR introduces a reusable `AppFooter` component and integrates it into the team layout, while also adding a contact form link to the landing page footer.

## Key Changes
- **New Component**: Created `AppFooter` component (`components/app-footer.tsx`) with consistent styling and a contact form link
- **Team Layout Update**: Modified `app/[teamId]/layout.tsx` to:
  - Import and use the new `AppFooter` component
  - Restructure layout to use flexbox (`flex min-h-screen flex-col`) to ensure footer sticks to bottom
  - Wrap children in a flex container with `flex-1` to push footer down
- **Landing Page Enhancement**: Added contact form link to the footer in `app/page.tsx` with appropriate styling for dark theme

## Implementation Details
- The `AppFooter` component uses consistent styling with smaller text (`text-xs`) and slate-400 color for the app description
- Contact link includes proper accessibility attributes (`target="_blank"`, `rel="noopener noreferrer"`)
- Team layout now uses a flexbox column layout to ensure the footer remains at the bottom of the viewport even with minimal content
- Both footers link to the same Google Form for feedback/inquiries

https://claude.ai/code/session_01JL4azRjSHPidfvUabEYsWZ