### PR TITLE
feat: チーム登録完了時にメール送信を追加

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,3 +6,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 NEXT_PUBLIC_IS_PREVIEW=true
 PREVIEW_AUTO_LOGIN_EMAIL=test@example.com
 PREVIEW_AUTO_LOGIN_PASSWORD=your-test-password
+
+# メール送信（Resend）
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+EMAIL_FROM=やきゅスコ <noreply@yourdomain.com>

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { sendTeamRegistrationEmail } from "@/lib/email";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
@@ -50,6 +51,16 @@ export async function GET(request: Request) {
     if (insertError) {
       console.error("Team insert error:", insertError);
       return NextResponse.redirect(`${origin}/register?error=team_creation_failed`);
+    }
+
+    if (user.email) {
+      sendTeamRegistrationEmail({
+        to: user.email,
+        teamName,
+        teamUrl: `${origin}/${teamId}`,
+      }).catch((err: unknown) => {
+        console.error("Team registration email failed:", err);
+      });
     }
   }
 

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -44,8 +44,7 @@ function buildHtml({ teamName, teamUrl }: HtmlParams): string {
     .steps { list-style: none; padding: 0; margin: 0; }
     .steps li { display: flex; align-items: flex-start; gap: 12px; padding: 10px 0; border-bottom: 1px solid #f1f5f9; font-size: 14px; color: #475569; }
     .steps li:last-child { border-bottom: none; }
-    .step-num { background: #2563eb; color: #fff; border-radius: 50%; width: 22px; height: 22px; display: inline-flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 700; flex-shrink: 0; margin-top: 1px; }
-    .step-link { color: #2563eb; font-size: 12px; display: block; margin-top: 2px; }
+    .step-num { font-weight: 700; color: #1e293b; flex-shrink: 0; }
     .footer { margin-top: 32px; padding-top: 20px; border-top: 1px solid #e2e8f0; text-align: center; font-size: 12px; color: #94a3b8; }
   </style>
 </head>
@@ -63,31 +62,19 @@ function buildHtml({ teamName, teamUrl }: HtmlParams): string {
     <ul class="steps">
       <li>
         <span class="step-num">1</span>
-        <div>
-          <strong>管理者ログイン</strong> — チームページから管理者としてサインインします<br>
-          <a href="${teamUrl}/login" class="step-link">${teamUrl}/login</a>
-        </div>
+        <div><strong>管理者ログイン</strong> — チームページから管理者としてサインインします</div>
       </li>
       <li>
         <span class="step-num">2</span>
-        <div>
-          <strong>選手を追加する</strong> — 選手一覧ページでメンバーを登録します<br>
-          <a href="${teamUrl}/players" class="step-link">${teamUrl}/players</a>
-        </div>
+        <div><strong>選手を追加する</strong> — 選手一覧ページでメンバーを登録します</div>
       </li>
       <li>
         <span class="step-num">3</span>
-        <div>
-          <strong>試合を記録する</strong> — 新しい試合のスコアと打撃成績を入力します<br>
-          <a href="${teamUrl}/games/new" class="step-link">${teamUrl}/games/new</a>
-        </div>
+        <div><strong>試合を記録する</strong> — 試合登録からURLを共有して、みんなでスコアを入力します</div>
       </li>
       <li>
         <span class="step-num">4</span>
-        <div>
-          <strong>個人成績を確認する</strong> — 選手ごとの打率・成績を一覧で確認できます<br>
-          <a href="${teamUrl}/stats" class="step-link">${teamUrl}/stats</a>
-        </div>
+        <div><strong>個人成績を確認する</strong> — 選手ごとの打率・成績を一覧で確認できます</div>
       </li>
     </ul>
 

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,0 +1,101 @@
+import { Resend } from "resend";
+import { APP_NAME } from "@/lib/constants";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export interface TeamRegistrationEmailParams {
+  to: string;
+  teamName: string;
+  teamUrl: string;
+}
+
+export async function sendTeamRegistrationEmail(
+  params: TeamRegistrationEmailParams
+): Promise<void> {
+  const { to, teamName, teamUrl } = params;
+  await resend.emails.send({
+    from: process.env.EMAIL_FROM ?? "noreply@example.com",
+    to,
+    subject: `【${APP_NAME}】${teamName} の登録が完了しました`,
+    html: buildHtml({ teamName, teamUrl }),
+  });
+}
+
+interface HtmlParams {
+  teamName: string;
+  teamUrl: string;
+}
+
+function buildHtml({ teamName, teamUrl }: HtmlParams): string {
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${APP_NAME} チーム登録完了</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f1f5f9; margin: 0; padding: 24px; }
+    .container { max-width: 560px; margin: 0 auto; background: #ffffff; border-radius: 16px; padding: 40px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+    .header { text-align: center; margin-bottom: 32px; }
+    .header h1 { font-size: 22px; color: #1e293b; margin: 0 0 8px; }
+    .header p { font-size: 14px; color: #64748b; margin: 0; }
+    .team-url-box { display: block; background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 8px; padding: 14px 20px; color: #2563eb; font-size: 15px; font-weight: 600; text-decoration: none; text-align: center; margin: 24px 0; }
+    .section-title { font-size: 15px; font-weight: 700; color: #1e293b; margin: 28px 0 12px; }
+    .steps { list-style: none; padding: 0; margin: 0; }
+    .steps li { display: flex; align-items: flex-start; gap: 12px; padding: 10px 0; border-bottom: 1px solid #f1f5f9; font-size: 14px; color: #475569; }
+    .steps li:last-child { border-bottom: none; }
+    .step-num { background: #2563eb; color: #fff; border-radius: 50%; width: 22px; height: 22px; display: inline-flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 700; flex-shrink: 0; margin-top: 1px; }
+    .step-link { color: #2563eb; font-size: 12px; display: block; margin-top: 2px; }
+    .footer { margin-top: 32px; padding-top: 20px; border-top: 1px solid #e2e8f0; text-align: center; font-size: 12px; color: #94a3b8; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1>チーム登録が完了しました</h1>
+      <p>${APP_NAME} へようこそ、<strong>${teamName}</strong> の管理者さん！</p>
+    </div>
+
+    <p style="font-size:14px;color:#475569;margin:0 0 8px;">チームページはこちらからアクセスできます：</p>
+    <a href="${teamUrl}" class="team-url-box">${teamUrl}</a>
+
+    <p class="section-title">はじめにやること</p>
+    <ul class="steps">
+      <li>
+        <span class="step-num">1</span>
+        <div>
+          <strong>管理者ログイン</strong> — チームページから管理者としてサインインします<br>
+          <a href="${teamUrl}/login" class="step-link">${teamUrl}/login</a>
+        </div>
+      </li>
+      <li>
+        <span class="step-num">2</span>
+        <div>
+          <strong>選手を追加する</strong> — 選手一覧ページでメンバーを登録します<br>
+          <a href="${teamUrl}/players" class="step-link">${teamUrl}/players</a>
+        </div>
+      </li>
+      <li>
+        <span class="step-num">3</span>
+        <div>
+          <strong>試合を記録する</strong> — 新しい試合のスコアと打撃成績を入力します<br>
+          <a href="${teamUrl}/games/new" class="step-link">${teamUrl}/games/new</a>
+        </div>
+      </li>
+      <li>
+        <span class="step-num">4</span>
+        <div>
+          <strong>個人成績を確認する</strong> — 選手ごとの打率・成績を一覧で確認できます<br>
+          <a href="${teamUrl}/stats" class="step-link">${teamUrl}/stats</a>
+        </div>
+      </li>
+    </ul>
+
+    <div class="footer">
+      <p>${APP_NAME} — チームの記録を管理するアプリ</p>
+      <p>このメールはチーム登録完了時に自動送信されています。</p>
+    </div>
+  </div>
+</body>
+</html>`;
+}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-hook-form": "^7.54.1",
     "react-resizable-panels": "^2.1.7",
     "recharts": "2.15.0",
+    "resend": "^6.12.2",
     "sonner": "^1.7.1",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       recharts:
         specifier: 2.15.0
         version: 2.15.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      resend:
+        specifier: ^6.12.2
+        version: 6.12.2
       sonner:
         specifier: ^1.7.1
         version: 1.7.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1109,6 +1112,9 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@supabase/auth-js@2.104.1':
     resolution: {integrity: sha512-pqFnDKekq1isqlqnzqzyJ3mzmho+o+FjfVTqhKY3PFlwj2anx3OPznO1kbo1ZEwD8zg1r4EAFf/7pplLyX0ocQ==}
     engines: {node: '>=20.0.0'}
@@ -1451,6 +1457,9 @@ packages:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -1613,6 +1622,9 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
@@ -1712,6 +1724,15 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  resend@6.12.2:
+    resolution: {integrity: sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -1734,6 +1755,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -1746,6 +1770,9 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  svix@1.90.0:
+    resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
 
   tailwind-merge@3.4.0:
     resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
@@ -1804,6 +1831,11 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   vaul@1.1.2:
     resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
@@ -2700,6 +2732,8 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@supabase/auth-js@2.104.1':
     dependencies:
       tslib: 2.8.1
@@ -2996,6 +3030,8 @@ snapshots:
 
   fast-equals@5.4.0: {}
 
+  fast-sha256@1.3.0: {}
+
   fraction.js@5.3.4: {}
 
   get-nonce@1.0.1: {}
@@ -3115,6 +3151,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
@@ -3223,6 +3261,11 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
+  resend@6.12.2:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.90.0
+
   scheduler@0.27.0: {}
 
   semver@7.7.4:
@@ -3267,10 +3310,20 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   styled-jsx@5.1.6(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
+
+  svix@1.90.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   tailwind-merge@3.4.0: {}
 
@@ -3312,6 +3365,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  uuid@10.0.0: {}
 
   vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:


### PR DESCRIPTION
メールアドレス確認完了時（/auth/callback）にResendを使って
チーム登録完了メールを送信する。メールにはチームトップURLと
管理者ログイン・選手追加・試合記録・成績確認の操作説明を含む。
メール送信失敗はリダイレクトをブロックしない（non-blocking）。

closes #80

https://claude.ai/code/session_01TmfzzJVgawKgbH52PVmn8v