### PR TITLE
feat: テーブルのスティッキー表示と縦書きを整理 (#70)

### DIFF
--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -514,7 +514,7 @@ export default function GameDetailPage() {
                     <th className="px-2 py-2 vertical-text">自責</th>
                   </tr>
                 </thead>
-                <tbody>
+                <tbody className="[writing-mode:horizontal-tb]">
                   {pitcherResults.map((pitcher, index) => (
                     <tr key={index} className="border-b">
                       <td className="sticky left-0 z-10 bg-white w-10 min-w-[40px] px-2 py-2">

--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -501,29 +501,29 @@ export default function GameDetailPage() {
               <table className="w-full text-center text-sm">
                 <thead>
                   <tr className="border-b bg-slate-50">
-                    <th className="px-2 py-2"></th>
-                    <th className="px-2 py-2 text-left">投手</th>
-                    <th className="px-2 py-2">投球回</th>
-                    <th className="px-2 py-2">打者</th>
-                    <th className="px-2 py-2">被安</th>
-                    <th className="px-2 py-2">被本</th>
-                    <th className="px-2 py-2">三振</th>
-                    <th className="px-2 py-2">四球</th>
-                    <th className="px-2 py-2">死球</th>
-                    <th className="px-2 py-2">失点</th>
-                    <th className="px-2 py-2">自責</th>
+                    <th className="sticky left-0 z-20 bg-slate-50 w-10 min-w-[40px] px-2 py-2"></th>
+                    <th className="sticky left-10 z-20 bg-slate-50 min-w-[5rem] px-2 py-2 text-left">投手</th>
+                    <th className="px-2 py-2"><span className="vertical-text">投球回</span></th>
+                    <th className="px-2 py-2"><span className="vertical-text">打者</span></th>
+                    <th className="px-2 py-2"><span className="vertical-text">被安</span></th>
+                    <th className="px-2 py-2"><span className="vertical-text">被本</span></th>
+                    <th className="px-2 py-2"><span className="vertical-text">三振</span></th>
+                    <th className="px-2 py-2"><span className="vertical-text">四球</span></th>
+                    <th className="px-2 py-2"><span className="vertical-text">死球</span></th>
+                    <th className="px-2 py-2"><span className="vertical-text">失点</span></th>
+                    <th className="px-2 py-2"><span className="vertical-text">自責</span></th>
                   </tr>
                 </thead>
                 <tbody>
                   {pitcherResults.map((pitcher, index) => (
                     <tr key={index} className="border-b">
-                      <td className="px-2 py-2">
+                      <td className="sticky left-0 z-10 bg-white w-10 min-w-[40px] px-2 py-2">
                         {pitcher.pitcher_award === 'win'  && <span className="rounded bg-blue-100 px-1 text-blue-700">勝</span>}
                         {pitcher.pitcher_award === 'lose' && <span className="rounded bg-red-100 px-1 text-red-700">敗</span>}
                         {pitcher.pitcher_award === 'save' && <span className="rounded bg-green-100 px-1 text-green-700">S</span>}
                         {pitcher.pitcher_award === 'hold' && <span className="rounded bg-purple-100 px-1 text-purple-700">H</span>}
                       </td>
-                      <td className="px-2 py-2 text-left font-medium">{pitcher.player_name}</td>
+                      <td className="sticky left-10 z-10 bg-white min-w-[5rem] px-2 py-2 text-left font-medium">{pitcher.player_name}</td>
                       <td className="px-2 py-2">{formatInnings(pitcher.innings_outs, pitcher.is_mid_inning_exit)}</td>
                       <td className="px-2 py-2">{pitcher.batters_faced ?? 0}</td>
                       <td className="px-2 py-2">{pitcher.hits}</td>

--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -503,15 +503,15 @@ export default function GameDetailPage() {
                   <tr className="border-b bg-slate-50">
                     <th className="sticky left-0 z-20 bg-slate-50 w-10 min-w-[40px] px-2 py-2"></th>
                     <th className="sticky left-10 z-20 bg-slate-50 min-w-[5rem] px-2 py-2 text-left">投手</th>
-                    <th className="px-2 py-2"><span className="vertical-text">投球回</span></th>
-                    <th className="px-2 py-2"><span className="vertical-text">打者</span></th>
-                    <th className="px-2 py-2"><span className="vertical-text">被安</span></th>
-                    <th className="px-2 py-2"><span className="vertical-text">被本</span></th>
-                    <th className="px-2 py-2"><span className="vertical-text">三振</span></th>
-                    <th className="px-2 py-2"><span className="vertical-text">四球</span></th>
-                    <th className="px-2 py-2"><span className="vertical-text">死球</span></th>
-                    <th className="px-2 py-2"><span className="vertical-text">失点</span></th>
-                    <th className="px-2 py-2"><span className="vertical-text">自責</span></th>
+                    <th className="px-2 py-2 vertical-text">投球回</th>
+                    <th className="px-2 py-2 vertical-text">打者</th>
+                    <th className="px-2 py-2 vertical-text">被安</th>
+                    <th className="px-2 py-2 vertical-text">被本</th>
+                    <th className="px-2 py-2 vertical-text">三振</th>
+                    <th className="px-2 py-2 vertical-text">四球</th>
+                    <th className="px-2 py-2 vertical-text">死球</th>
+                    <th className="px-2 py-2 vertical-text">失点</th>
+                    <th className="px-2 py-2 vertical-text">自責</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -517,7 +517,7 @@ export default function GameDetailPage() {
                 <tbody className="[writing-mode:horizontal-tb]">
                   {pitcherResults.map((pitcher, index) => (
                     <tr key={index} className="border-b">
-                      <td className="sticky left-0 z-10 bg-white w-10 min-w-[40px] px-2 py-2">
+                      <td className="sticky left-0 z-10 bg-white w-10 min-w-[40px] px-2 py-2 [text-orientation:upright]">
                         {pitcher.pitcher_award === 'win'  && <span className="rounded bg-blue-100 px-1 text-blue-700">勝</span>}
                         {pitcher.pitcher_award === 'lose' && <span className="rounded bg-red-100 px-1 text-red-700">敗</span>}
                         {pitcher.pitcher_award === 'save' && <span className="rounded bg-green-100 px-1 text-green-700">S</span>}

--- a/app/[teamId]/stats/page.tsx
+++ b/app/[teamId]/stats/page.tsx
@@ -251,8 +251,8 @@ export default function StatsPage() {
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b bg-slate-50">
-                      <th 
-                        className="sticky left-0 z-10 bg-slate-50 px-3 py-3 text-left cursor-pointer hover:bg-slate-100"
+                      <th
+                        className="sticky left-0 z-10 bg-slate-50 px-3 py-3 text-left cursor-pointer hover:bg-slate-100 whitespace-nowrap"
                         onClick={() => handleBattingSort("playerName")}
                       >
                         <span className="flex items-center gap-1">
@@ -284,7 +284,7 @@ export default function StatsPage() {
                           index === 0 && battingSortKey === "battingAverage" && "bg-yellow-50"
                         )}
                       >
-                        <td className="sticky left-0 z-10 bg-white px-3 py-3 font-medium">
+                        <td className="sticky left-0 z-10 bg-white px-3 py-3 font-medium whitespace-nowrap">
                           {player.playerName}
                         </td>
                         {visibleBattingColumns.map((col) => (
@@ -328,8 +328,8 @@ export default function StatsPage() {
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b bg-slate-50">
-                      <th 
-                        className="sticky left-0 z-10 bg-slate-50 px-3 py-3 text-left cursor-pointer hover:bg-slate-100"
+                      <th
+                        className="sticky left-0 z-10 bg-slate-50 px-3 py-3 text-left cursor-pointer hover:bg-slate-100 whitespace-nowrap"
                         onClick={() => handlePitchingSort("playerName")}
                       >
                         <span className="flex items-center gap-1">
@@ -361,7 +361,7 @@ export default function StatsPage() {
                           index === 0 && pitchingSortKey === "era" && sortDirection === "asc" && "bg-yellow-50"
                         )}
                       >
-                        <td className="sticky left-0 z-10 bg-white px-3 py-3 font-medium">
+                        <td className="sticky left-0 z-10 bg-white px-3 py-3 font-medium whitespace-nowrap">
                           {player.playerName}
                         </td>
                         {visiblePitchingColumns.map((col) => (

--- a/app/[teamId]/stats/page.tsx
+++ b/app/[teamId]/stats/page.tsx
@@ -263,13 +263,12 @@ export default function StatsPage() {
                       {visibleBattingColumns.map((col) => (
                         <th
                           key={col.key}
-                          className="px-2 py-3 text-center cursor-pointer hover:bg-slate-100 whitespace-nowrap"
+                          className="px-2 py-3 text-center cursor-pointer hover:bg-slate-100"
                           onClick={() => handleBattingSort(col.key)}
                           title={col.label}
                         >
-                          <span className="flex items-center justify-center gap-1">
-                            <span className="hidden sm:inline">{col.label}</span>
-                            <span className="sm:hidden">{col.shortLabel}</span>
+                          <span className="flex flex-col items-center justify-center gap-1">
+                            <span className="vertical-text">{col.label}</span>
                             <SortIcon active={battingSortKey === col.key} />
                           </span>
                         </th>
@@ -341,13 +340,12 @@ export default function StatsPage() {
                       {visiblePitchingColumns.map((col) => (
                         <th
                           key={col.key}
-                          className="px-2 py-3 text-center cursor-pointer hover:bg-slate-100 whitespace-nowrap"
+                          className="px-2 py-3 text-center cursor-pointer hover:bg-slate-100"
                           onClick={() => handlePitchingSort(col.key)}
                           title={col.label}
                         >
-                          <span className="flex items-center justify-center gap-1">
-                            <span className="hidden sm:inline">{col.label}</span>
-                            <span className="sm:hidden">{col.shortLabel}</span>
+                          <span className="flex flex-col items-center justify-center gap-1">
+                            <span className="vertical-text">{col.label}</span>
                             <SortIcon active={pitchingSortKey === col.key} />
                           </span>
                         </th>

--- a/app/[teamId]/stats/page.tsx
+++ b/app/[teamId]/stats/page.tsx
@@ -273,7 +273,7 @@ export default function StatsPage() {
                       ))}
                     </tr>
                   </thead>
-                  <tbody>
+                  <tbody className="[writing-mode:horizontal-tb]">
                     {sortedBattingStats.map((player, index) => (
                       <tr 
                         key={player.playerId} 
@@ -348,7 +348,7 @@ export default function StatsPage() {
                       ))}
                     </tr>
                   </thead>
-                  <tbody>
+                  <tbody className="[writing-mode:horizontal-tb]">
                     {sortedPitchingStats.map((player, index) => (
                       <tr 
                         key={player.playerId} 

--- a/app/[teamId]/stats/page.tsx
+++ b/app/[teamId]/stats/page.tsx
@@ -263,14 +263,12 @@ export default function StatsPage() {
                       {visibleBattingColumns.map((col) => (
                         <th
                           key={col.key}
-                          className="px-2 py-3 text-center cursor-pointer hover:bg-slate-100"
+                          className="px-2 py-3 text-center cursor-pointer hover:bg-slate-100 vertical-text"
                           onClick={() => handleBattingSort(col.key)}
                           title={col.label}
                         >
-                          <span className="flex flex-col items-center justify-center gap-1">
-                            <span className="vertical-text">{col.label}</span>
-                            <SortIcon active={battingSortKey === col.key} />
-                          </span>
+                          {col.label}
+                          <SortIcon active={battingSortKey === col.key} />
                         </th>
                       ))}
                     </tr>
@@ -340,14 +338,12 @@ export default function StatsPage() {
                       {visiblePitchingColumns.map((col) => (
                         <th
                           key={col.key}
-                          className="px-2 py-3 text-center cursor-pointer hover:bg-slate-100"
+                          className="px-2 py-3 text-center cursor-pointer hover:bg-slate-100 vertical-text"
                           onClick={() => handlePitchingSort(col.key)}
                           title={col.label}
                         >
-                          <span className="flex flex-col items-center justify-center gap-1">
-                            <span className="vertical-text">{col.label}</span>
-                            <SortIcon active={pitchingSortKey === col.key} />
-                          </span>
+                          {col.label}
+                          <SortIcon active={pitchingSortKey === col.key} />
                         </th>
                       ))}
                     </tr>

--- a/app/globals.css
+++ b/app/globals.css
@@ -124,6 +124,11 @@
   }
 }
 
+@utility vertical-text {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+}
+
 @keyframes score-pop {
   0%   { transform: scale(1); }
   45%  { transform: scale(1.45); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -126,7 +126,7 @@
 
 @utility vertical-text {
   writing-mode: vertical-rl;
-  text-orientation: mixed;
+  text-orientation: upright;
 }
 
 @keyframes score-pop {


### PR DESCRIPTION
- 試合結果画面の投手成績テーブルで決着列・投手名列をsticky固定表示に変更し、他の列は横スクロールに
- 試合結果画面の投手成績テーブルの列名を縦書きに変更（投球回の折り返しを解消）
- 成績一覧画面（打撃・投手）の選手名以外の列名を縦書きに変更
- globals.cssにvertical-textユーティリティクラスを追加

https://claude.ai/code/session_0188wahsvGL32JjcKG4weHzp