### PR TITLE
feat: LPのSEO対策を実施

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,47 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
-import { APP_NAME } from '@/lib/constants'
+import { APP_NAME, SITE_URL } from '@/lib/constants'
 import './globals.css'
 
 const _geist = Geist({ subsets: ["latin"] });
 const _geistMono = Geist_Mono({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: APP_NAME,
-  description: `${APP_NAME} - 野球の試合結果・打撃成績・投手成績を記録するアプリ`,
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: `${APP_NAME} - 野球チームの成績管理アプリ`,
+    template: `%s | ${APP_NAME}`,
+  },
+  description: `${APP_NAME}は野球チームの試合スコア・打撃成績・投手成績をスマホから簡単に記録・管理できる無料Webアプリです。打率・OPS・防御率を自動計算。`,
+  keywords: ['野球', 'チーム管理', 'スコア記録', '打撃成績', '投手成績', '野球スコアブック', '少年野球', '草野球', '成績管理'],
   generator: 'next.js',
+  openGraph: {
+    type: 'website',
+    locale: 'ja_JP',
+    url: SITE_URL,
+    siteName: APP_NAME,
+    title: `${APP_NAME} - 野球チームの成績管理アプリ`,
+    description: `野球チームの試合スコア・打撃成績・投手成績をスマホから簡単に記録・管理。打率・OPS・防御率を自動計算。無料で使えます。`,
+    images: [
+      {
+        url: '/opengraph-image',
+        width: 1200,
+        height: 630,
+        alt: `${APP_NAME} - 野球チームの成績管理アプリ`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${APP_NAME} - 野球チームの成績管理アプリ`,
+    description: `野球チームの試合スコア・打撃成績・投手成績をスマホから簡単に記録・管理。打率・OPS・防御率を自動計算。無料で使えます。`,
+    images: ['/opengraph-image'],
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
   icons: {
     icon: [
       {

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,92 @@
+import { ImageResponse } from 'next/og'
+import { APP_NAME } from '@/lib/constants'
+
+export const runtime = 'edge'
+export const alt = `${APP_NAME} - 野球チームの成績管理アプリ`
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(to bottom, #0f172a, #1e293b)',
+          padding: '60px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '24px',
+          }}
+        >
+          <div
+            style={{
+              fontSize: '80px',
+              fontWeight: 'bold',
+              color: 'white',
+              lineHeight: 1.1,
+            }}
+          >
+            {APP_NAME}
+          </div>
+          <div
+            style={{
+              fontSize: '36px',
+              color: '#94a3b8',
+              textAlign: 'center',
+            }}
+          >
+            野球チームの試合結果と個人成績を簡単管理
+          </div>
+          <div
+            style={{
+              marginTop: '16px',
+              display: 'flex',
+              gap: '16px',
+            }}
+          >
+            {['試合スコア記録', '打率・OPS自動計算', '投手成績管理'].map((label) => (
+              <div
+                key={label}
+                style={{
+                  background: 'rgba(59, 130, 246, 0.2)',
+                  border: '1px solid rgba(59, 130, 246, 0.4)',
+                  borderRadius: '8px',
+                  padding: '8px 20px',
+                  color: '#93c5fd',
+                  fontSize: '22px',
+                }}
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+          <div
+            style={{
+              marginTop: '24px',
+              background: '#2563eb',
+              borderRadius: '12px',
+              padding: '14px 40px',
+              color: 'white',
+              fontSize: '26px',
+              fontWeight: 'bold',
+            }}
+          >
+            無料で始める
+          </div>
+        </div>
+      </div>
+    ),
+    size,
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,32 @@
+import type { Metadata } from "next"
 import Link from "next/link"
 import { Users, BarChart3, Calendar, ChevronRight } from "lucide-react"
-import { APP_NAME } from "@/lib/constants"
+import { APP_NAME, SITE_URL } from "@/lib/constants"
 import { ScoreSharingDemo } from "@/components/score-sharing-demo"
+
+export const metadata: Metadata = {
+  title: "野球チームの成績管理アプリ",
+  description: `${APP_NAME}は野球チームの試合スコア・打撃成績・投手成績をスマホから簡単に記録・管理できる無料Webアプリです。打率・OPS・防御率を自動計算。チーム登録は無料・クレジットカード不要。`,
+  alternates: {
+    canonical: "/",
+  },
+}
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: APP_NAME,
+  applicationCategory: "SportsApplication",
+  operatingSystem: "Web",
+  inLanguage: "ja",
+  url: SITE_URL,
+  description: "野球チームの試合スコア・打撃成績・投手成績をスマホから簡単に記録・管理できる無料Webアプリ。打率・OPS・防御率を自動計算。",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "JPY",
+  },
+}
 
 export default function LandingPage() {
   return (
@@ -9,7 +34,7 @@ export default function LandingPage() {
       {/* ヘッダー */}
       <header className="mx-auto max-w-6xl px-4 py-6">
         <nav className="flex items-center justify-between">
-          <h1 className="text-2xl font-bold text-white">{APP_NAME}</h1>
+          <span className="text-2xl font-bold text-white">{APP_NAME}</span>
           <div className="flex items-center gap-4">
             <Link
               href="/register"
@@ -23,9 +48,9 @@ export default function LandingPage() {
 
       {/* ヒーローセクション */}
       <section className="mx-auto max-w-6xl px-4 py-16 text-center md:py-24">
-        <h2 className="text-4xl font-bold leading-tight text-white md:text-5xl">
+        <h1 className="text-4xl font-bold leading-tight text-white md:text-5xl">
           チームの試合結果と<br />個人成績を簡単管理
-        </h2>
+        </h1>
         <p className="mx-auto mt-6 max-w-2xl text-lg text-slate-300">
           野球チームの試合スコア、打撃成績、投手成績を一元管理。
           スマートフォンからいつでも簡単に記録・確認できます。
@@ -49,13 +74,13 @@ export default function LandingPage() {
 
       {/* 機能紹介 */}
       <section className="mx-auto max-w-6xl px-4 py-16">
-        <h3 className="mb-12 text-center text-2xl font-bold text-white">主な機能</h3>
+        <h2 className="mb-12 text-center text-2xl font-bold text-white">主な機能</h2>
         <div className="grid gap-8 md:grid-cols-3">
           <div className="rounded-2xl bg-slate-800/50 p-6">
             <div className="mb-4 inline-flex rounded-xl bg-blue-500/20 p-3">
               <Calendar className="h-8 w-8 text-blue-400" />
             </div>
-            <h4 className="mb-2 text-xl font-bold text-white">試合結果の記録</h4>
+            <h3 className="mb-2 text-xl font-bold text-white">試合結果の記録</h3>
             <p className="text-slate-400">
               スコアボード形式で各イニングのスコアを記録。
               打撃結果もタップ操作で簡単入力。
@@ -65,7 +90,7 @@ export default function LandingPage() {
             <div className="mb-4 inline-flex rounded-xl bg-emerald-500/20 p-3">
               <BarChart3 className="h-8 w-8 text-emerald-400" />
             </div>
-            <h4 className="mb-2 text-xl font-bold text-white">個人成績の自動集計</h4>
+            <h3 className="mb-2 text-xl font-bold text-white">個人成績の自動集計</h3>
             <p className="text-slate-400">
               打率、出塁率、OPS、防御率などを自動計算。
               選手ごとの成績を一覧で確認。
@@ -75,7 +100,7 @@ export default function LandingPage() {
             <div className="mb-4 inline-flex rounded-xl bg-purple-500/20 p-3">
               <Users className="h-8 w-8 text-purple-400" />
             </div>
-            <h4 className="mb-2 text-xl font-bold text-white">選手一覧</h4>
+            <h3 className="mb-2 text-xl font-bold text-white">選手一覧</h3>
             <p className="text-slate-400">
               チームメンバーを登録して、試合ごとの出場選手を簡単選択。
               背番号やポジションも管理。
@@ -100,9 +125,9 @@ export default function LandingPage() {
       {/* CTA */}
       <section className="mx-auto max-w-6xl px-4 py-16 text-center">
         <div className="rounded-3xl bg-gradient-to-r from-blue-600 to-blue-700 p-8 md:p-12">
-          <h3 className="text-2xl font-bold text-white md:text-3xl">
+          <h2 className="text-2xl font-bold text-white md:text-3xl">
             今すぐチームを作成して始めましょう
-          </h3>
+          </h2>
           <p className="mt-4 text-blue-100">
             無料で使えます。クレジットカード不要。
           </p>
@@ -132,6 +157,11 @@ export default function LandingPage() {
           </p>
         </div>
       </footer>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
     </main>
   )
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next'
+import { SITE_URL } from '@/lib/constants'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/'],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next'
+import { SITE_URL } from '@/lib/constants'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: SITE_URL,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/register`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/demo`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.6,
+    },
+  ]
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,1 +1,2 @@
 export const APP_NAME = "やきゅスコ"
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://yakyusco.kamata.men"


### PR DESCRIPTION
- lib/constants.ts に SITE_URL 定数を追加
- app/layout.tsx にメタデータを強化（metadataBase、OGP、Twitter Card、keywords）
- app/page.tsx でLP固有のメタデータをexport、見出し階層を修正（h1をヒーローに）、JSON-LD（SoftwareApplication）を追加
- app/opengraph-image.tsx を新規作成（動的OGP画像 1200×630px）
- app/robots.ts を新規作成（robots.txt 自動生成）
- app/sitemap.ts を新規作成（sitemap.xml 自動生成）

https://claude.ai/code/session_01DwudR5og4ekeFhkeNcDQoq