### PR TITLE
feat: チーム画面からLPへの導線を追加

### DIFF
--- a/components/app-footer.tsx
+++ b/components/app-footer.tsx
@@ -1,10 +1,15 @@
+import Link from "next/link"
 import { APP_NAME } from "@/lib/constants"
 
 export function AppFooter() {
   return (
     <footer className="border-t border-slate-200 py-4 mt-auto">
       <div className="mx-auto max-w-6xl px-4 text-center text-xs text-slate-400">
-        <p>{APP_NAME} - チームの記録を管理するアプリ</p>
+        <p>
+          <Link href="/" className="hover:text-slate-600 transition-colors">
+            {APP_NAME} - チームの記録を管理するアプリ
+          </Link>
+        </p>
         <p className="mt-1">
           <a
             href="https://forms.gle/wPRQDXBgRxCD5JqPA"

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import Image from "next/image"
 import { usePathname, useParams, useRouter } from "next/navigation"
-import { Home, List, BarChart3, Users, Menu, X, LogIn, LogOut, Shield } from "lucide-react"
+import { Home, List, BarChart3, Users, Menu, X, LogIn, LogOut, Shield, ExternalLink } from "lucide-react"
 import { useState, useEffect } from "react"
 import { cn } from "@/lib/utils"
 import { APP_NAME } from "@/lib/constants"
@@ -162,6 +162,13 @@ export function AppHeader({ teamName: initialTeamName }: AppHeaderProps) {
                   </DropdownMenuItem>
                 </>
               )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem asChild>
+                <Link href="/" className="flex items-center">
+                  <ExternalLink className="h-4 w-4 mr-2" />
+                  やきゅスコについて
+                </Link>
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </nav>
@@ -230,6 +237,14 @@ export function AppHeader({ teamName: initialTeamName }: AppHeaderProps) {
                 管理者ログイン
               </Link>
             )}
+            <Link
+              href="/"
+              onClick={() => setIsMenuOpen(false)}
+              className="flex items-center gap-3 rounded-lg px-3 py-3 text-sm font-medium text-slate-600 hover:bg-slate-100"
+            >
+              <ExternalLink className="h-5 w-5" />
+              やきゅスコについて
+            </Link>
           </div>
         </nav>
       )}


### PR DESCRIPTION
- フッターの「やきゅスコ - チームの記録を管理するアプリ」をLPへのリンクに変更
- ヘッダードロップダウン（デスクトップ・モバイル両対応）に「やきゅスコについて」リンクを追加

https://claude.ai/code/session_01FQydTPvoRJMgV1cWYJs1VM