### PR TITLE
feat: 投手成績のイニングごと入力機能を追加 (#93)

### DIFF
--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -4,9 +4,10 @@ import { Edit } from "lucide-react"
 import { createClient } from "@/lib/supabase/server"
 import { requireTeamAdmin } from "@/lib/auth"
 import { cn } from "@/lib/utils"
-import type { BattingResult } from "@/lib/batting-types"
+import type { BattingResult, PitcherInningStats } from "@/lib/batting-types"
 import { getResultSummary, isHit, isOnBase } from "@/lib/batting-types"
 import { DeleteButton } from "./delete-button"
+import { PitcherResultsSection } from "./pitcher-results-section"
 
 export const dynamic = "force-dynamic"
 
@@ -45,6 +46,40 @@ export default async function GameDetailPage({ params }: Props) {
     ...r,
     player_name: r.players?.name || r.player_name,
     players: undefined,
+  }))
+
+  // イニングごとの投手成績を取得
+  const pitcherIds = pitcherResults.map((p: { id: string }) => p.id)
+  let pitcherInningStatsMap: Record<string, PitcherInningStats[]> = {}
+  if (pitcherIds.length > 0) {
+    const { data: rawInningStats } = await supabase
+      .from("pitcher_inning_stats")
+      .select("*")
+      .in("pitcher_result_id", pitcherIds)
+      .order("inning")
+    if (rawInningStats) {
+      for (const row of rawInningStats) {
+        if (!pitcherInningStatsMap[row.pitcher_result_id]) {
+          pitcherInningStatsMap[row.pitcher_result_id] = []
+        }
+        pitcherInningStatsMap[row.pitcher_result_id].push({
+          inning: row.inning,
+          runs: row.runs,
+          hits: row.hits,
+          strikeouts: row.strikeouts,
+          earnedRuns: row.earned_runs,
+          walks: row.walks,
+          hitByPitch: row.hit_by_pitch,
+          homeRuns: row.home_runs,
+          battersFaced: row.batters_faced,
+        })
+      }
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pitcherResultsWithInning = pitcherResults.map((p: any) => ({
+    ...p,
+    inningStats: pitcherInningStatsMap[p.id] ?? [],
   }))
   const isAdmin = !!adminSession
 
@@ -303,54 +338,7 @@ export default async function GameDetailPage({ params }: Props) {
           </div>
         </div>
 
-        <div className="rounded-2xl bg-white shadow-lg overflow-hidden">
-          <h2 className="px-4 py-3 text-sm font-bold text-slate-600 border-b border-slate-200 bg-slate-50">投手成績</h2>
-          {pitcherResults.length > 0 ? (
-            <div className="overflow-x-auto">
-              <table className="w-full text-center text-sm">
-                <thead>
-                  <tr className="border-b bg-slate-50">
-                    <th className="sticky left-0 z-20 bg-slate-50 w-10 min-w-[40px] px-2 py-2"></th>
-                    <th className="sticky left-10 z-20 bg-slate-50 min-w-[5rem] px-2 py-2 text-left">投手</th>
-                    <th className="px-2 py-2 vertical-text">投球回</th>
-                    <th className="px-2 py-2 vertical-text">打者</th>
-                    <th className="px-2 py-2 vertical-text">被安</th>
-                    <th className="px-2 py-2 vertical-text">被本</th>
-                    <th className="px-2 py-2 vertical-text">三振</th>
-                    <th className="px-2 py-2 vertical-text">四球</th>
-                    <th className="px-2 py-2 vertical-text">死球</th>
-                    <th className="px-2 py-2 vertical-text">失点</th>
-                    <th className="px-2 py-2 vertical-text">自責</th>
-                  </tr>
-                </thead>
-                <tbody className="[writing-mode:horizontal-tb]">
-                  {pitcherResults.map((pitcher: { pitcher_award: string | null; player_name: string; innings_outs: number; is_mid_inning_exit: boolean; batters_faced?: number; hits: number; home_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; runs: number; earned_runs: number }, index: number) => (
-                    <tr key={index} className="border-b">
-                      <td className="sticky left-0 z-10 bg-white w-10 min-w-[40px] px-2 py-2 [text-orientation:upright]">
-                        {pitcher.pitcher_award === "win" && <span className="rounded bg-blue-100 px-1 text-blue-700">勝</span>}
-                        {pitcher.pitcher_award === "lose" && <span className="rounded bg-red-100 px-1 text-red-700">敗</span>}
-                        {pitcher.pitcher_award === "save" && <span className="rounded bg-green-100 px-1 text-green-700">S</span>}
-                        {pitcher.pitcher_award === "hold" && <span className="rounded bg-purple-100 px-1 text-purple-700">H</span>}
-                      </td>
-                      <td className="sticky left-10 z-10 bg-white min-w-[5rem] px-2 py-2 text-left font-medium">{pitcher.player_name}</td>
-                      <td className="px-2 py-2">{formatInnings(pitcher.innings_outs, pitcher.is_mid_inning_exit)}</td>
-                      <td className="px-2 py-2">{pitcher.batters_faced ?? 0}</td>
-                      <td className="px-2 py-2">{pitcher.hits}</td>
-                      <td className="px-2 py-2">{pitcher.home_runs}</td>
-                      <td className="px-2 py-2">{pitcher.strikeouts}</td>
-                      <td className="px-2 py-2">{pitcher.walks}</td>
-                      <td className="px-2 py-2">{pitcher.hit_by_pitch}</td>
-                      <td className="px-2 py-2">{pitcher.runs}</td>
-                      <td className="px-2 py-2">{pitcher.earned_runs}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ) : (
-            <p className="p-4 py-8 text-center text-slate-400">投手成績が登録されていません</p>
-          )}
-        </div>
+        <PitcherResultsSection pitchers={pitcherResultsWithInning} totalInnings={totalInnings} />
       </div>
     </main>
   )

--- a/app/[teamId]/games/[id]/page.tsx
+++ b/app/[teamId]/games/[id]/page.tsx
@@ -64,6 +64,7 @@ export default async function GameDetailPage({ params }: Props) {
         }
         pitcherInningStatsMap[row.pitcher_result_id].push({
           inning: row.inning,
+          outs: row.outs ?? 3,
           runs: row.runs,
           hits: row.hits,
           strikeouts: row.strikeouts,

--- a/app/[teamId]/games/[id]/pitcher-results-section.tsx
+++ b/app/[teamId]/games/[id]/pitcher-results-section.tsx
@@ -35,7 +35,7 @@ function formatInnings(outs: number, isMidInningExit: boolean): string {
 }
 
 function sumInningStats(stats: PitcherInningStats[]) {
-  return stats.reduce(
+  const totals = stats.reduce(
     (acc, s) => ({
       hits: acc.hits + s.hits,
       runs: acc.runs + s.runs,
@@ -45,9 +45,12 @@ function sumInningStats(stats: PitcherInningStats[]) {
       hitByPitch: acc.hitByPitch + s.hitByPitch,
       homeRuns: acc.homeRuns + s.homeRuns,
       battersFaced: acc.battersFaced + s.battersFaced,
+      totalOuts: acc.totalOuts + (s.outs ?? 3),
     }),
-    { hits: 0, runs: 0, earnedRuns: 0, strikeouts: 0, walks: 0, hitByPitch: 0, homeRuns: 0, battersFaced: 0 }
+    { hits: 0, runs: 0, earnedRuns: 0, strikeouts: 0, walks: 0, hitByPitch: 0, homeRuns: 0, battersFaced: 0, totalOuts: 0 }
   )
+  const lastInning = stats[stats.length - 1]
+  return { ...totals, isMidInningExit: lastInning ? (lastInning.outs ?? 3) < 3 : false }
 }
 
 const STAT_ROWS = ["失点", "安打", "三振"] as const
@@ -123,18 +126,20 @@ export function PitcherResultsSection({ pitchers, totalInnings }: Props) {
             </thead>
             <tbody className="[writing-mode:horizontal-tb]">
               {pitchers.map((pitcher, index) => {
-                const stats = pitcher.inningStats.length > 0
-                  ? sumInningStats(pitcher.inningStats)
-                  : {
-                      hits: pitcher.hits,
-                      runs: pitcher.runs,
-                      earnedRuns: pitcher.earned_runs,
-                      strikeouts: pitcher.strikeouts,
-                      walks: pitcher.walks,
-                      hitByPitch: pitcher.hit_by_pitch,
-                      homeRuns: pitcher.home_runs,
-                      battersFaced: pitcher.batters_faced ?? 0,
-                    }
+                const hasInning = pitcher.inningStats.length > 0
+                const inningSum = hasInning ? sumInningStats(pitcher.inningStats) : null
+                const stats = inningSum ?? {
+                  hits: pitcher.hits,
+                  runs: pitcher.runs,
+                  earnedRuns: pitcher.earned_runs,
+                  strikeouts: pitcher.strikeouts,
+                  walks: pitcher.walks,
+                  hitByPitch: pitcher.hit_by_pitch,
+                  homeRuns: pitcher.home_runs,
+                  battersFaced: pitcher.batters_faced ?? 0,
+                }
+                const inningsOuts = inningSum ? inningSum.totalOuts : pitcher.innings_outs
+                const isMidInningExit = inningSum ? inningSum.isMidInningExit : pitcher.is_mid_inning_exit
                 return (
                   <tr key={index} className="border-b">
                     <td className="sticky left-0 z-10 bg-white w-10 min-w-[40px] px-2 py-2 [text-orientation:upright]">
@@ -143,8 +148,8 @@ export function PitcherResultsSection({ pitchers, totalInnings }: Props) {
                       {pitcher.pitcher_award === "save" && <span className="rounded bg-green-100 px-1 text-green-700">S</span>}
                       {pitcher.pitcher_award === "hold" && <span className="rounded bg-purple-100 px-1 text-purple-700">H</span>}
                     </td>
-                    <td className="sticky left-10 z-10 bg-white min-w-[5rem] px-2 py-2 text-left font-medium">{pitcher.player_name}</td>
-                    <td className="px-2 py-2">{formatInnings(pitcher.innings_outs, pitcher.is_mid_inning_exit)}</td>
+                    <td className="sticky left-10 z-10 bg-white min-w-[4rem] max-w-[5rem] px-2 py-2 text-left font-medium">{pitcher.player_name}</td>
+                    <td className="px-2 py-2">{formatInnings(inningsOuts, isMidInningExit)}</td>
                     <td className="px-2 py-2">{stats.battersFaced}</td>
                     <td className="px-2 py-2">{stats.hits}</td>
                     <td className="px-2 py-2">{stats.homeRuns}</td>
@@ -165,7 +170,7 @@ export function PitcherResultsSection({ pitchers, totalInnings }: Props) {
             <thead className="bg-slate-50 text-slate-600">
               <tr>
                 <th className="px-2 py-2 text-center font-medium w-8">#</th>
-                <th className="px-3 py-2 text-left font-medium min-w-[5rem]">投手</th>
+                <th className="px-2 py-2 text-left font-medium min-w-[4rem] max-w-[5rem]">投手</th>
                 <th className="px-2 py-2 text-center font-medium w-10">項目</th>
                 {inningColumns.map(n => (
                   <th key={n} className="px-1 py-2 text-center font-medium w-8">{n}</th>
@@ -179,7 +184,7 @@ export function PitcherResultsSection({ pitchers, totalInnings }: Props) {
                     {sIdx === 0 && (
                       <>
                         <td rowSpan={3} className="px-2 py-1 text-center text-slate-500 align-middle">{pIdx + 1}</td>
-                        <td rowSpan={3} className="px-3 py-1 align-middle">
+                        <td rowSpan={3} className="px-2 py-1 align-middle min-w-[4rem] max-w-[5rem]">
                           <div className="flex flex-col gap-0.5">
                             <div className="flex items-center gap-1">
                               {pitcher.pitcher_award === "win"  && <span className="text-xs text-amber-500 font-bold">勝</span>}

--- a/app/[teamId]/games/[id]/pitcher-results-section.tsx
+++ b/app/[teamId]/games/[id]/pitcher-results-section.tsx
@@ -1,0 +1,218 @@
+"use client"
+
+import { useState } from "react"
+import { cn } from "@/lib/utils"
+import type { PitcherInningStats } from "@/lib/batting-types"
+
+interface PitcherRow {
+  id: string
+  pitcher_award: string | null
+  player_name: string
+  innings_outs: number
+  is_mid_inning_exit: boolean
+  batters_faced?: number
+  hits: number
+  home_runs: number
+  strikeouts: number
+  walks: number
+  hit_by_pitch: number
+  runs: number
+  earned_runs: number
+  inningStats: PitcherInningStats[]
+}
+
+interface Props {
+  pitchers: PitcherRow[]
+  totalInnings: number
+}
+
+function formatInnings(outs: number, isMidInningExit: boolean): string {
+  const whole = Math.floor(outs / 3)
+  const rem = outs % 3
+  if (rem === 0 && isMidInningExit) return `${whole} 0/3`
+  if (rem === 0) return `${whole}`
+  return `${whole} ${rem}/3`
+}
+
+function sumInningStats(stats: PitcherInningStats[]) {
+  return stats.reduce(
+    (acc, s) => ({
+      hits: acc.hits + s.hits,
+      runs: acc.runs + s.runs,
+      earnedRuns: acc.earnedRuns + s.earnedRuns,
+      strikeouts: acc.strikeouts + s.strikeouts,
+      walks: acc.walks + s.walks,
+      hitByPitch: acc.hitByPitch + s.hitByPitch,
+      homeRuns: acc.homeRuns + s.homeRuns,
+      battersFaced: acc.battersFaced + s.battersFaced,
+    }),
+    { hits: 0, runs: 0, earnedRuns: 0, strikeouts: 0, walks: 0, hitByPitch: 0, homeRuns: 0, battersFaced: 0 }
+  )
+}
+
+const STAT_ROWS = ["失点", "安打", "三振"] as const
+
+export function PitcherResultsSection({ pitchers, totalInnings }: Props) {
+  const hasInningData = pitchers.some(p => p.inningStats.length > 0)
+  const [viewMode, setViewMode] = useState<"aggregate" | "inning">("aggregate")
+
+  if (pitchers.length === 0) {
+    return (
+      <div className="rounded-2xl bg-white shadow-lg overflow-hidden">
+        <h2 className="px-4 py-3 text-sm font-bold text-slate-600 border-b border-slate-200 bg-slate-50">投手成績</h2>
+        <p className="p-4 py-8 text-center text-slate-400">投手成績が登録されていません</p>
+      </div>
+    )
+  }
+
+  const inningColumns = Array.from({ length: totalInnings }, (_, i) => i + 1)
+
+  const getInningValue = (pitcher: PitcherRow, inning: number, stat: typeof STAT_ROWS[number]): number | null => {
+    const s = pitcher.inningStats.find(x => x.inning === inning)
+    if (!s) return null
+    if (stat === "失点") return s.runs
+    if (stat === "安打") return s.hits
+    return s.strikeouts
+  }
+
+  return (
+    <div className="rounded-2xl bg-white shadow-lg overflow-hidden">
+      <div className="px-4 py-3 border-b border-slate-200 bg-slate-50 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-bold text-slate-600">投手成績</h2>
+        {hasInningData && (
+          <div className="flex rounded-lg border border-slate-200 overflow-hidden text-xs font-medium">
+            <button
+              onClick={() => setViewMode("aggregate")}
+              className={cn(
+                "px-3 py-1.5 transition-colors",
+                viewMode === "aggregate" ? "bg-blue-600 text-white" : "bg-white text-slate-600 hover:bg-slate-50"
+              )}
+            >
+              試合合計
+            </button>
+            <button
+              onClick={() => setViewMode("inning")}
+              className={cn(
+                "px-3 py-1.5 transition-colors",
+                viewMode === "inning" ? "bg-blue-600 text-white" : "bg-white text-slate-600 hover:bg-slate-50"
+              )}
+            >
+              イニングごと
+            </button>
+          </div>
+        )}
+      </div>
+
+      {viewMode === "aggregate" ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-center text-sm">
+            <thead>
+              <tr className="border-b bg-slate-50">
+                <th className="sticky left-0 z-20 bg-slate-50 w-10 min-w-[40px] px-2 py-2"></th>
+                <th className="sticky left-10 z-20 bg-slate-50 min-w-[5rem] px-2 py-2 text-left">投手</th>
+                <th className="px-2 py-2 vertical-text">投球回</th>
+                <th className="px-2 py-2 vertical-text">打者</th>
+                <th className="px-2 py-2 vertical-text">被安</th>
+                <th className="px-2 py-2 vertical-text">被本</th>
+                <th className="px-2 py-2 vertical-text">三振</th>
+                <th className="px-2 py-2 vertical-text">四球</th>
+                <th className="px-2 py-2 vertical-text">死球</th>
+                <th className="px-2 py-2 vertical-text">失点</th>
+                <th className="px-2 py-2 vertical-text">自責</th>
+              </tr>
+            </thead>
+            <tbody className="[writing-mode:horizontal-tb]">
+              {pitchers.map((pitcher, index) => {
+                const stats = pitcher.inningStats.length > 0
+                  ? sumInningStats(pitcher.inningStats)
+                  : {
+                      hits: pitcher.hits,
+                      runs: pitcher.runs,
+                      earnedRuns: pitcher.earned_runs,
+                      strikeouts: pitcher.strikeouts,
+                      walks: pitcher.walks,
+                      hitByPitch: pitcher.hit_by_pitch,
+                      homeRuns: pitcher.home_runs,
+                      battersFaced: pitcher.batters_faced ?? 0,
+                    }
+                return (
+                  <tr key={index} className="border-b">
+                    <td className="sticky left-0 z-10 bg-white w-10 min-w-[40px] px-2 py-2 [text-orientation:upright]">
+                      {pitcher.pitcher_award === "win"  && <span className="rounded bg-blue-100 px-1 text-blue-700">勝</span>}
+                      {pitcher.pitcher_award === "lose" && <span className="rounded bg-red-100 px-1 text-red-700">敗</span>}
+                      {pitcher.pitcher_award === "save" && <span className="rounded bg-green-100 px-1 text-green-700">S</span>}
+                      {pitcher.pitcher_award === "hold" && <span className="rounded bg-purple-100 px-1 text-purple-700">H</span>}
+                    </td>
+                    <td className="sticky left-10 z-10 bg-white min-w-[5rem] px-2 py-2 text-left font-medium">{pitcher.player_name}</td>
+                    <td className="px-2 py-2">{formatInnings(pitcher.innings_outs, pitcher.is_mid_inning_exit)}</td>
+                    <td className="px-2 py-2">{stats.battersFaced}</td>
+                    <td className="px-2 py-2">{stats.hits}</td>
+                    <td className="px-2 py-2">{stats.homeRuns}</td>
+                    <td className="px-2 py-2">{stats.strikeouts}</td>
+                    <td className="px-2 py-2">{stats.walks}</td>
+                    <td className="px-2 py-2">{stats.hitByPitch}</td>
+                    <td className="px-2 py-2">{stats.runs}</td>
+                    <td className="px-2 py-2">{stats.earnedRuns}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead className="bg-slate-50 text-slate-600">
+              <tr>
+                <th className="px-2 py-2 text-center font-medium w-8">#</th>
+                <th className="px-3 py-2 text-left font-medium min-w-[5rem]">投手</th>
+                <th className="px-2 py-2 text-center font-medium w-10">項目</th>
+                {inningColumns.map(n => (
+                  <th key={n} className="px-1 py-2 text-center font-medium w-8">{n}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {pitchers.map((pitcher, pIdx) =>
+                STAT_ROWS.map((stat, sIdx) => (
+                  <tr key={`${pIdx}-${stat}`} className={cn("border-t border-slate-100", sIdx === 0 && pIdx > 0 && "border-t-2 border-slate-200")}>
+                    {sIdx === 0 && (
+                      <>
+                        <td rowSpan={3} className="px-2 py-1 text-center text-slate-500 align-middle">{pIdx + 1}</td>
+                        <td rowSpan={3} className="px-3 py-1 align-middle">
+                          <div className="flex flex-col gap-0.5">
+                            <div className="flex items-center gap-1">
+                              {pitcher.pitcher_award === "win"  && <span className="text-xs text-amber-500 font-bold">勝</span>}
+                              {pitcher.pitcher_award === "lose" && <span className="text-xs text-slate-500 font-bold">敗</span>}
+                              {pitcher.pitcher_award === "save" && <span className="text-xs text-blue-500 font-bold">S</span>}
+                              {pitcher.pitcher_award === "hold" && <span className="text-xs text-emerald-500 font-bold">H</span>}
+                              <span className="font-medium text-slate-800">{pitcher.player_name}</span>
+                            </div>
+                            <span className="text-xs text-slate-400">{formatInnings(pitcher.innings_outs, pitcher.is_mid_inning_exit)}</span>
+                          </div>
+                        </td>
+                      </>
+                    )}
+                    <td className="px-2 py-1 text-center text-xs text-slate-500 whitespace-nowrap">{stat}</td>
+                    {inningColumns.map(inning => {
+                      const val = getInningValue(pitcher, inning, stat)
+                      return (
+                        <td key={inning} className="px-1 py-1 text-center">
+                          {val !== null ? (
+                            <span className={cn("font-medium", val > 0 && stat === "失点" && "text-red-600")}>{val}</span>
+                          ) : (
+                            <span className="text-slate-200">-</span>
+                          )}
+                        </td>
+                      )
+                    })}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/[teamId]/games/[id]/pitcher-results-section.tsx
+++ b/app/[teamId]/games/[id]/pitcher-results-section.tsx
@@ -185,15 +185,12 @@ export function PitcherResultsSection({ pitchers, totalInnings }: Props) {
                       <>
                         <td rowSpan={3} className="px-2 py-1 text-center text-slate-500 align-middle">{pIdx + 1}</td>
                         <td rowSpan={3} className="px-2 py-1 align-middle min-w-[4rem] max-w-[5rem]">
-                          <div className="flex flex-col gap-0.5">
-                            <div className="flex items-center gap-1">
-                              {pitcher.pitcher_award === "win"  && <span className="text-xs text-amber-500 font-bold">勝</span>}
-                              {pitcher.pitcher_award === "lose" && <span className="text-xs text-slate-500 font-bold">敗</span>}
-                              {pitcher.pitcher_award === "save" && <span className="text-xs text-blue-500 font-bold">S</span>}
-                              {pitcher.pitcher_award === "hold" && <span className="text-xs text-emerald-500 font-bold">H</span>}
-                              <span className="font-medium text-slate-800">{pitcher.player_name}</span>
-                            </div>
-                            <span className="text-xs text-slate-400">{formatInnings(pitcher.innings_outs, pitcher.is_mid_inning_exit)}</span>
+                          <div className="flex items-center gap-1 flex-wrap">
+                            {pitcher.pitcher_award === "win"  && <span className="text-xs text-amber-500 font-bold">勝</span>}
+                            {pitcher.pitcher_award === "lose" && <span className="text-xs text-slate-500 font-bold">敗</span>}
+                            {pitcher.pitcher_award === "save" && <span className="text-xs text-blue-500 font-bold">S</span>}
+                            {pitcher.pitcher_award === "hold" && <span className="text-xs text-emerald-500 font-bold">H</span>}
+                            <span className="font-medium text-slate-800">{pitcher.player_name}</span>
                           </div>
                         </td>
                       </>

--- a/app/[teamId]/stats/page.tsx
+++ b/app/[teamId]/stats/page.tsx
@@ -56,7 +56,7 @@ export default async function StatsPage({ params }: Props) {
 
   // イニングごとの成績を取得（存在する場合は集計値として使用）
   const pitcherResultIds = (pitcherResultsResult.data ?? []).map((r: { id: string }) => r.id)
-  const inningStatsMap = new Map<string, { hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; batters_faced: number }>()
+  const inningStatsMap = new Map<string, { hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; batters_faced: number; outs_pitched: number }>()
   if (pitcherResultIds.length > 0) {
     const { data: inningRows } = await supabase
       .from("pitcher_inning_stats")
@@ -64,7 +64,7 @@ export default async function StatsPage({ params }: Props) {
       .in("pitcher_result_id", pitcherResultIds)
     if (inningRows) {
       for (const row of inningRows) {
-        const prev = inningStatsMap.get(row.pitcher_result_id) ?? { hits: 0, runs: 0, earned_runs: 0, strikeouts: 0, walks: 0, hit_by_pitch: 0, home_runs: 0, batters_faced: 0 }
+        const prev = inningStatsMap.get(row.pitcher_result_id) ?? { hits: 0, runs: 0, earned_runs: 0, strikeouts: 0, walks: 0, hit_by_pitch: 0, home_runs: 0, batters_faced: 0, outs_pitched: 0 }
         inningStatsMap.set(row.pitcher_result_id, {
           hits: prev.hits + row.hits,
           runs: prev.runs + row.runs,
@@ -74,6 +74,7 @@ export default async function StatsPage({ params }: Props) {
           hit_by_pitch: prev.hit_by_pitch + row.hit_by_pitch,
           home_runs: prev.home_runs + row.home_runs,
           batters_faced: prev.batters_faced + row.batters_faced,
+          outs_pitched: prev.outs_pitched + (row.outs ?? 3),
         })
       }
     }
@@ -148,7 +149,7 @@ export default async function StatsPage({ params }: Props) {
       pitcherResultsMap.set(result.player_id, { name: pitcherName, results: [] })
     }
     pitcherResultsMap.get(result.player_id)!.results.push({
-      outs_pitched: result.innings_outs || 0,
+      outs_pitched: inning ? inning.outs_pitched : (result.innings_outs || 0),
       hits: inning ? inning.hits : (result.hits || 0),
       runs: inning ? inning.runs : (result.runs || 0),
       earned_runs: inning ? inning.earned_runs : (result.earned_runs || 0),

--- a/app/[teamId]/stats/page.tsx
+++ b/app/[teamId]/stats/page.tsx
@@ -54,6 +54,31 @@ export default async function StatsPage({ params }: Props) {
       .in("game_id", gameIds),
   ])
 
+  // イニングごとの成績を取得（存在する場合は集計値として使用）
+  const pitcherResultIds = (pitcherResultsResult.data ?? []).map((r: { id: string }) => r.id)
+  const inningStatsMap = new Map<string, { hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; batters_faced: number }>()
+  if (pitcherResultIds.length > 0) {
+    const { data: inningRows } = await supabase
+      .from("pitcher_inning_stats")
+      .select("*")
+      .in("pitcher_result_id", pitcherResultIds)
+    if (inningRows) {
+      for (const row of inningRows) {
+        const prev = inningStatsMap.get(row.pitcher_result_id) ?? { hits: 0, runs: 0, earned_runs: 0, strikeouts: 0, walks: 0, hit_by_pitch: 0, home_runs: 0, batters_faced: 0 }
+        inningStatsMap.set(row.pitcher_result_id, {
+          hits: prev.hits + row.hits,
+          runs: prev.runs + row.runs,
+          earned_runs: prev.earned_runs + row.earned_runs,
+          strikeouts: prev.strikeouts + row.strikeouts,
+          walks: prev.walks + row.walks,
+          hit_by_pitch: prev.hit_by_pitch + row.hit_by_pitch,
+          home_runs: prev.home_runs + row.home_runs,
+          batters_faced: prev.batters_faced + row.batters_faced,
+        })
+      }
+    }
+  }
+
   // 打順エントリーから選手とゲームの紐付けを作成
   const battingOrderMap = new Map<string, { playerId: string; playerName: string }>()
   for (const entry of lineupResult.data ?? []) {
@@ -116,19 +141,22 @@ export default async function StatsPage({ params }: Props) {
     const pitcherPlayerData = (result as any).players as { name: string } | null
     const pitcherName = pitcherPlayerData?.name || result.player_name
 
+    // イニングデータがある場合はその合計を使用、なければ集約フィールドを使用
+    const inning = inningStatsMap.get(result.id)
+
     if (!pitcherResultsMap.has(result.player_id)) {
       pitcherResultsMap.set(result.player_id, { name: pitcherName, results: [] })
     }
     pitcherResultsMap.get(result.player_id)!.results.push({
       outs_pitched: result.innings_outs || 0,
-      hits: result.hits || 0,
-      runs: result.runs || 0,
-      earned_runs: result.earned_runs || 0,
-      strikeouts: result.strikeouts || 0,
-      walks: result.walks || 0,
-      hit_by_pitch: result.hit_by_pitch || 0,
-      home_runs: result.home_runs || 0,
-      batters_faced: result.batters_faced || 0,
+      hits: inning ? inning.hits : (result.hits || 0),
+      runs: inning ? inning.runs : (result.runs || 0),
+      earned_runs: inning ? inning.earned_runs : (result.earned_runs || 0),
+      strikeouts: inning ? inning.strikeouts : (result.strikeouts || 0),
+      walks: inning ? inning.walks : (result.walks || 0),
+      hit_by_pitch: inning ? inning.hit_by_pitch : (result.hit_by_pitch || 0),
+      home_runs: inning ? inning.home_runs : (result.home_runs || 0),
+      batters_faced: inning ? inning.batters_faced : (result.batters_faced || 0),
       pitcher_award: result.pitcher_award ?? null,
     })
   }

--- a/app/api/games/[id]/pitchers/route.ts
+++ b/app/api/games/[id]/pitchers/route.ts
@@ -4,6 +4,7 @@ import { requireGameAccess } from "@/lib/auth"
 
 interface PitcherInningStatsInput {
   inning: number
+  outs: number
   runs: number
   hits: number
   strikeouts: number
@@ -98,6 +99,7 @@ export async function POST(
         const inningInserts: Array<{
           pitcher_result_id: string
           inning: number
+          outs: number
           runs: number
           hits: number
           strikeouts: number
@@ -115,6 +117,7 @@ export async function POST(
               inningInserts.push({
                 pitcher_result_id: inserted.id,
                 inning: s.inning,
+                outs: s.outs ?? 3,
                 runs: s.runs,
                 hits: s.hits,
                 strikeouts: s.strikeouts,

--- a/app/api/games/[id]/pitchers/route.ts
+++ b/app/api/games/[id]/pitchers/route.ts
@@ -2,7 +2,19 @@ import { createClient } from "@/lib/supabase/server"
 import { NextResponse } from "next/server"
 import { requireGameAccess } from "@/lib/auth"
 
-interface PitcherResult {
+interface PitcherInningStatsInput {
+  inning: number
+  runs: number
+  hits: number
+  strikeouts: number
+  earnedRuns: number
+  walks: number
+  hitByPitch: number
+  homeRuns: number
+  battersFaced: number
+}
+
+interface PitcherResultInput {
   playerId?: string
   playerName: string
   outsPitched: number
@@ -18,6 +30,7 @@ interface PitcherResult {
   pitchCount?: number
   award?: string | null
   isHelper?: boolean
+  inningStats?: PitcherInningStatsInput[]
 }
 
 // 投手成績を保存（都度保存用 - 全体を置き換え）
@@ -28,7 +41,7 @@ export async function POST(
   const { id: gameId } = await params
   const body = await request.json()
   const { pitchers, shareToken } = body as {
-    pitchers: PitcherResult[]
+    pitchers: PitcherResultInput[]
     shareToken?: string
   }
 
@@ -40,7 +53,7 @@ export async function POST(
 
   const supabase = await createClient()
 
-  // 既存の投手成績を削除
+  // 既存の投手成績を削除（CASCADE で pitcher_inning_stats も削除）
   await supabase
     .from("pitcher_results")
     .delete()
@@ -49,7 +62,7 @@ export async function POST(
   // 新しい投手成績を挿入
   if (pitchers && pitchers.length > 0) {
     const validPitchers = pitchers.filter(p => p.playerName && p.playerName.trim() !== "")
-    
+
     if (validPitchers.length > 0) {
       const insertData = validPitchers.map((p, index) => ({
         game_id: gameId,
@@ -71,12 +84,58 @@ export async function POST(
         order_index: index,
       }))
 
-      const { error } = await supabase
+      const { data: insertedPitchers, error } = await supabase
         .from("pitcher_results")
         .insert(insertData)
+        .select("id, order_index")
 
       if (error) {
         return NextResponse.json({ error: error.message }, { status: 500 })
+      }
+
+      // イニングごとの成績を挿入
+      if (insertedPitchers) {
+        const inningInserts: Array<{
+          pitcher_result_id: string
+          inning: number
+          runs: number
+          hits: number
+          strikeouts: number
+          earned_runs: number
+          walks: number
+          hit_by_pitch: number
+          home_runs: number
+          batters_faced: number
+        }> = []
+
+        for (const inserted of insertedPitchers) {
+          const pitcher = validPitchers[inserted.order_index]
+          if (pitcher?.inningStats && pitcher.inningStats.length > 0) {
+            for (const s of pitcher.inningStats) {
+              inningInserts.push({
+                pitcher_result_id: inserted.id,
+                inning: s.inning,
+                runs: s.runs,
+                hits: s.hits,
+                strikeouts: s.strikeouts,
+                earned_runs: s.earnedRuns,
+                walks: s.walks,
+                hit_by_pitch: s.hitByPitch,
+                home_runs: s.homeRuns,
+                batters_faced: s.battersFaced,
+              })
+            }
+          }
+        }
+
+        if (inningInserts.length > 0) {
+          const { error: inningError } = await supabase
+            .from("pitcher_inning_stats")
+            .insert(inningInserts)
+          if (inningError) {
+            return NextResponse.json({ error: inningError.message }, { status: 500 })
+          }
+        }
       }
     }
   }

--- a/app/api/games/[id]/route.ts
+++ b/app/api/games/[id]/route.ts
@@ -62,12 +62,47 @@ export async function GET(
     players: undefined,
   }))
 
+  // イニングごとの投手成績を取得
+  const pitcherResultIds = pitcherResults.map((p: { id: string }) => p.id)
+  let inningStatsMap: Record<string, unknown[]> = {}
+  if (pitcherResultIds.length > 0) {
+    const { data: rawInningStats } = await supabase
+      .from("pitcher_inning_stats")
+      .select("*")
+      .in("pitcher_result_id", pitcherResultIds)
+      .order("inning")
+    if (rawInningStats) {
+      for (const row of rawInningStats) {
+        if (!inningStatsMap[row.pitcher_result_id]) {
+          inningStatsMap[row.pitcher_result_id] = []
+        }
+        inningStatsMap[row.pitcher_result_id].push({
+          inning: row.inning,
+          runs: row.runs,
+          hits: row.hits,
+          strikeouts: row.strikeouts,
+          earnedRuns: row.earned_runs,
+          walks: row.walks,
+          hitByPitch: row.hit_by_pitch,
+          homeRuns: row.home_runs,
+          battersFaced: row.batters_faced,
+        })
+      }
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pitcherResultsWithInning = pitcherResults.map((p: any) => ({
+    ...p,
+    inningStats: inningStatsMap[p.id] || [],
+  }))
+
   return NextResponse.json({
     game,
     inningScores: inningScores || [],
     lineupEntries,
     battingResults: battingResults || [],
-    pitcherResults,
+    pitcherResults: pitcherResultsWithInning,
   })
 }
 
@@ -225,7 +260,7 @@ export async function PUT(
 
   // 投手成績を挿入
   if (pitchers && pitchers.length > 0) {
-    const pitcherInserts = pitchers.map((p: {
+    type PitcherInput = {
       playerId?: string
       playerName: string
       outsPitched: number
@@ -241,7 +276,19 @@ export async function PUT(
       pitchCount?: number
       award?: string | null
       isHelper?: boolean
-    }, index: number) => ({
+      inningStats?: Array<{
+        inning: number
+        runs: number
+        hits: number
+        strikeouts: number
+        earnedRuns: number
+        walks: number
+        hitByPitch: number
+        homeRuns: number
+        battersFaced: number
+      }>
+    }
+    const pitcherInserts = (pitchers as PitcherInput[]).map((p, index) => ({
       game_id: id,
       player_id: p.playerId && p.playerId.trim() !== "" ? p.playerId : null,
       player_name: p.playerName,
@@ -260,7 +307,48 @@ export async function PUT(
       is_helper: p.isHelper || false,
       order_index: index,
     }))
-    await supabase.from("pitcher_results").insert(pitcherInserts)
+    const { data: insertedPitchers } = await supabase
+      .from("pitcher_results")
+      .insert(pitcherInserts)
+      .select("id, order_index")
+
+    // イニングごとの成績を挿入
+    if (insertedPitchers) {
+      const inningInserts: Array<{
+        pitcher_result_id: string
+        inning: number
+        runs: number
+        hits: number
+        strikeouts: number
+        earned_runs: number
+        walks: number
+        hit_by_pitch: number
+        home_runs: number
+        batters_faced: number
+      }> = []
+      for (const inserted of insertedPitchers) {
+        const pitcher = (pitchers as PitcherInput[])[inserted.order_index]
+        if (pitcher?.inningStats && pitcher.inningStats.length > 0) {
+          for (const s of pitcher.inningStats) {
+            inningInserts.push({
+              pitcher_result_id: inserted.id,
+              inning: s.inning,
+              runs: s.runs,
+              hits: s.hits,
+              strikeouts: s.strikeouts,
+              earned_runs: s.earnedRuns,
+              walks: s.walks,
+              hit_by_pitch: s.hitByPitch,
+              home_runs: s.homeRuns,
+              batters_faced: s.battersFaced,
+            })
+          }
+        }
+      }
+      if (inningInserts.length > 0) {
+        await supabase.from("pitcher_inning_stats").insert(inningInserts)
+      }
+    }
   }
 
   return NextResponse.json({ success: true })

--- a/app/api/games/[id]/route.ts
+++ b/app/api/games/[id]/route.ts
@@ -78,6 +78,7 @@ export async function GET(
         }
         inningStatsMap[row.pitcher_result_id].push({
           inning: row.inning,
+          outs: row.outs ?? 3,
           runs: row.runs,
           hits: row.hits,
           strikeouts: row.strikeouts,
@@ -278,6 +279,7 @@ export async function PUT(
       isHelper?: boolean
       inningStats?: Array<{
         inning: number
+        outs: number
         runs: number
         hits: number
         strikeouts: number
@@ -317,6 +319,7 @@ export async function PUT(
       const inningInserts: Array<{
         pitcher_result_id: string
         inning: number
+        outs: number
         runs: number
         hits: number
         strikeouts: number
@@ -333,6 +336,7 @@ export async function PUT(
             inningInserts.push({
               pitcher_result_id: inserted.id,
               inning: s.inning,
+              outs: s.outs ?? 3,
               runs: s.runs,
               hits: s.hits,
               strikeouts: s.strikeouts,

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -124,7 +124,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack, player
     inningScores?: { inning: number; our_score: number; opponent_score: number }[]
     lineupEntries?: { batting_order: number; player_id: string; player_name: string; positions?: string[]; is_substitute: boolean; entered_inning?: number; is_helper: boolean }[]
     battingResults?: { batting_order: number; inning: number; at_bat_sequence?: number; hit_result: string; direction: string; rbi_count: number; scored?: boolean; runner_first: boolean; runner_second: boolean; runner_third: boolean; stolen_second: boolean; stolen_third: boolean; stolen_home: boolean }[]
-    pitcherResults?: { player_id?: string; player_name: string; innings_outs: number; is_mid_inning_exit: boolean; hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; batters_faced?: number; pitch_count?: number; pitcher_award?: string | null; is_helper?: boolean }[]
+    pitcherResults?: { player_id?: string; player_name: string; innings_outs: number; is_mid_inning_exit: boolean; hits: number; runs: number; earned_runs: number; strikeouts: number; walks: number; hit_by_pitch: number; home_runs: number; batters_faced?: number; pitch_count?: number; pitcher_award?: string | null; is_helper?: boolean; inningStats?: { inning: number; runs: number; hits: number; strikeouts: number; earnedRuns: number; walks: number; hitByPitch: number; homeRuns: number; battersFaced: number }[] }[]
   }) => {
     if (gameData.game) {
       setGameDate(gameData.game.date || "")
@@ -222,6 +222,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack, player
         pitchCount: p.pitch_count,
         award: p.pitcher_award ?? null,
         isHelper: p.is_helper || false,
+        inningStats: p.inningStats ?? [],
       })))
     }
   }, [])
@@ -701,6 +702,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack, player
           pitchers={pitchers}
           onPitchersChange={handlePitchersChange}
           registeredPlayers={registeredPlayers}
+          totalInnings={totalInnings}
         />
       </div>
 

--- a/components/pitcher-input.tsx
+++ b/components/pitcher-input.tsx
@@ -283,6 +283,19 @@ export function PitcherInput({
     setIsInningDialogOpen(false)
   }
 
+  const handleInningStatsDelete = () => {
+    const updated = [...pitchers]
+    const pitcher = { ...updated[inningDialogPitcherIndex] }
+    const stats = (pitcher.inningStats ?? []).filter(s => s.inning !== inningDialogInning)
+    pitcher.inningStats = stats
+    const agg = sumInningStats(stats)
+    pitcher.outsPitched = agg.outsPitched
+    pitcher.isMidInningExit = agg.isMidInningExit
+    updated[inningDialogPitcherIndex] = pitcher
+    onPitchersChange(updated)
+    setIsInningDialogOpen(false)
+  }
+
   // ── 共通UIパーツ ──
   const StatButton = ({
     label,
@@ -494,19 +507,16 @@ export function PitcherInput({
                     </td>
                     <td
                       rowSpan={3}
-                      className="px-3 py-1 align-middle cursor-pointer hover:bg-blue-50 transition-colors"
+                      className="px-2 py-1 align-middle min-w-[4rem] max-w-[5rem] cursor-pointer hover:bg-blue-50 transition-colors"
                       onClick={() => handleInningEditPlayer(pIdx)}
                     >
-                      <div className="flex flex-col gap-0.5">
-                        <div className="flex items-center gap-1">
-                          {pitcher.award === "win"  && <span className="text-xs text-amber-500 font-bold">勝</span>}
-                          {pitcher.award === "lose" && <span className="text-xs text-slate-500 font-bold">敗</span>}
-                          {pitcher.award === "save" && <span className="text-xs text-blue-500 font-bold">S</span>}
-                          {pitcher.award === "hold" && <span className="text-xs text-emerald-500 font-bold">H</span>}
-                          <span className="font-medium text-slate-800">{pitcher.playerName || <span className="text-slate-400">名前を設定</span>}</span>
-                          {pitcher.isHelper && <span className="text-xs px-1 rounded bg-purple-100 text-purple-600">助っ人</span>}
-                        </div>
-                        <span className="text-xs text-slate-400">{formatInnings(pitcher.outsPitched, pitcher.isMidInningExit)}</span>
+                      <div className="flex items-center gap-1 flex-wrap">
+                        {pitcher.award === "win"  && <span className="text-xs text-amber-500 font-bold">勝</span>}
+                        {pitcher.award === "lose" && <span className="text-xs text-slate-500 font-bold">敗</span>}
+                        {pitcher.award === "save" && <span className="text-xs text-blue-500 font-bold">S</span>}
+                        {pitcher.award === "hold" && <span className="text-xs text-emerald-500 font-bold">H</span>}
+                        <span className="font-medium text-slate-800">{pitcher.playerName || <span className="text-slate-400">名前を設定</span>}</span>
+                        {pitcher.isHelper && <span className="text-xs px-1 rounded bg-purple-100 text-purple-600">助っ人</span>}
                       </div>
                     </td>
                   </>
@@ -780,6 +790,15 @@ export function PitcherInput({
               <StatButton label="自責点" value={inningForm.earnedRuns} onChange={(v) => setInningForm({ ...inningForm, earnedRuns: v })} />
               <StatButton label="被本塁打" value={inningForm.homeRuns} onChange={(v) => setInningForm({ ...inningForm, homeRuns: v })} />
             </div>
+            {pitchers[inningDialogPitcherIndex]?.inningStats?.some(s => s.inning === inningDialogInning) && (
+              <Button
+                variant="outline"
+                className="w-full h-10 rounded-xl border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300"
+                onClick={handleInningStatsDelete}
+              >
+                このイニングのデータを削除
+              </Button>
+            )}
             <div className="flex gap-3">
               <Button variant="outline" className="flex-1 h-12 rounded-xl" onClick={() => setIsInningDialogOpen(false)}>キャンセル</Button>
               <Button className="flex-1 h-12 rounded-xl bg-blue-600 hover:bg-blue-700 text-white font-semibold" onClick={handleInningStatsSave}>保存</Button>

--- a/components/pitcher-input.tsx
+++ b/components/pitcher-input.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { cn } from "@/lib/utils"
-import type { PitcherResult, Player } from "@/lib/batting-types"
+import type { PitcherResult, PitcherInningStats, Player } from "@/lib/batting-types"
 import { Plus, Trash2, Trophy, ThumbsDown, Shield, Star, Minus } from "lucide-react"
 import { sortPlayersByNumber } from "@/lib/sort-utils"
 
@@ -12,6 +12,7 @@ interface PitcherInputProps {
   pitchers: PitcherResult[]
   onPitchersChange: (pitchers: PitcherResult[]) => void
   registeredPlayers?: Player[]
+  totalInnings?: number
 }
 
 export function formatInnings(outs: number, isMidInningExit: boolean): string {
@@ -36,100 +37,260 @@ function prevInnings(outs: number, isMidInningExit: boolean): [number, boolean] 
   return [newOuts, false]
 }
 
+type InputMode = "inning" | "aggregate"
+
+const EMPTY_PITCHER: PitcherResult = {
+  playerId: "",
+  playerName: "",
+  outsPitched: 0,
+  isMidInningExit: false,
+  hits: 0,
+  runs: 0,
+  earnedRuns: 0,
+  strikeouts: 0,
+  walks: 0,
+  hitByPitch: 0,
+  homeRuns: 0,
+  battersFaced: 0,
+  isHelper: false,
+  inningStats: [],
+}
+
+const EMPTY_INNING_STATS: PitcherInningStats = {
+  inning: 0,
+  runs: 0,
+  hits: 0,
+  strikeouts: 0,
+  earnedRuns: 0,
+  walks: 0,
+  hitByPitch: 0,
+  homeRuns: 0,
+  battersFaced: 0,
+}
+
+function sumInningStats(inningStats: PitcherInningStats[]): Pick<PitcherResult, "hits" | "runs" | "earnedRuns" | "strikeouts" | "walks" | "hitByPitch" | "homeRuns" | "battersFaced"> {
+  return inningStats.reduce(
+    (acc, s) => ({
+      hits: acc.hits + s.hits,
+      runs: acc.runs + s.runs,
+      earnedRuns: acc.earnedRuns + s.earnedRuns,
+      strikeouts: acc.strikeouts + s.strikeouts,
+      walks: acc.walks + s.walks,
+      hitByPitch: acc.hitByPitch + s.hitByPitch,
+      homeRuns: acc.homeRuns + s.homeRuns,
+      battersFaced: acc.battersFaced + s.battersFaced,
+    }),
+    { hits: 0, runs: 0, earnedRuns: 0, strikeouts: 0, walks: 0, hitByPitch: 0, homeRuns: 0, battersFaced: 0 }
+  )
+}
+
 export function PitcherInput({
   pitchers,
   onPitchersChange,
-  registeredPlayers = []
+  registeredPlayers = [],
+  totalInnings = 9,
 }: PitcherInputProps) {
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const [editingIndex, setEditingIndex] = useState<number | null>(null)
-  const [form, setForm] = useState<PitcherResult>({
-    playerId: "",
-    playerName: "",
-    outsPitched: 0,
-    isMidInningExit: false,
-    hits: 0,
-    runs: 0,
-    earnedRuns: 0,
-    strikeouts: 0,
-    walks: 0,
-    hitByPitch: 0,
-    homeRuns: 0,
-    battersFaced: 0,
-  })
+  const [inputMode, setInputMode] = useState<InputMode>("inning")
+  const [confirmDialog, setConfirmDialog] = useState<{ open: boolean; targetMode: InputMode }>({ open: false, targetMode: "aggregate" })
 
-  const handleAdd = () => {
-    setEditingIndex(null)
-    setForm({
-      playerId: "",
-      playerName: "",
-      outsPitched: 0,
-      isMidInningExit: false,
-      hits: 0,
-      runs: 0,
-      earnedRuns: 0,
-      strikeouts: 0,
-      walks: 0,
-      hitByPitch: 0,
-      homeRuns: 0,
-      battersFaced: 0,
-      isHelper: false,
-    })
-    setIsDialogOpen(true)
+  // プレーヤーデータに基づいてモードを初期化
+  useEffect(() => {
+    const hasInningData = pitchers.some(p => (p.inningStats?.length ?? 0) > 0)
+    const hasAggregateData = pitchers.some(p => p.hits > 0 || p.runs > 0 || p.strikeouts > 0)
+    if (!hasInningData && hasAggregateData) {
+      setInputMode("aggregate")
+    } else {
+      setInputMode("inning")
+    }
+  }, []) // 初回のみ
+
+  // 集約モード用の編集ダイアログ
+  const [isAggDialogOpen, setIsAggDialogOpen] = useState(false)
+  const [aggEditingIndex, setAggEditingIndex] = useState<number | null>(null)
+  const [aggForm, setAggForm] = useState<PitcherResult>(EMPTY_PITCHER)
+
+  // イニングモード用のプレーヤー編集ダイアログ
+  const [isPlayerDialogOpen, setIsPlayerDialogOpen] = useState(false)
+  const [playerEditingIndex, setPlayerEditingIndex] = useState<number | null>(null)
+  const [playerForm, setPlayerForm] = useState<PitcherResult>(EMPTY_PITCHER)
+
+  // イニングモード用のイニング統計ダイアログ
+  const [isInningDialogOpen, setIsInningDialogOpen] = useState(false)
+  const [inningDialogPitcherIndex, setInningDialogPitcherIndex] = useState<number>(0)
+  const [inningDialogInning, setInningDialogInning] = useState<number>(1)
+  const [inningForm, setInningForm] = useState<PitcherInningStats>(EMPTY_INNING_STATS)
+
+  const handleModeToggle = (newMode: InputMode) => {
+    if (newMode === inputMode) return
+
+    if (newMode === "aggregate") {
+      const hasInningData = pitchers.some(p => (p.inningStats?.length ?? 0) > 0)
+      if (hasInningData) {
+        setConfirmDialog({ open: true, targetMode: "aggregate" })
+        return
+      }
+    } else {
+      const hasAggregateData = pitchers.some(p => p.hits > 0 || p.runs > 0 || p.strikeouts > 0 || p.earnedRuns > 0 || p.walks > 0 || p.hitByPitch > 0 || p.homeRuns > 0 || (p.battersFaced ?? 0) > 0)
+      if (hasAggregateData) {
+        setConfirmDialog({ open: true, targetMode: "inning" })
+        return
+      }
+    }
+    setInputMode(newMode)
   }
 
-  const handleEdit = (index: number) => {
-    setEditingIndex(index)
-    setForm(pitchers[index])
-    setIsDialogOpen(true)
+  const handleConfirmModeSwitch = () => {
+    const targetMode = confirmDialog.targetMode
+    setConfirmDialog({ open: false, targetMode: "aggregate" })
+
+    if (targetMode === "aggregate") {
+      // イニング → 集約: inningStats の合計 → aggregate フィールドに、inningStats をクリア
+      const updated = pitchers.map(p => {
+        const stats = sumInningStats(p.inningStats ?? [])
+        return { ...p, ...stats, inningStats: [] }
+      })
+      onPitchersChange(updated)
+    } else {
+      // 集約 → イニング: aggregate フィールド → inning=1 のデータに変換、aggregate フィールドをリセット
+      const updated = pitchers.map(p => ({
+        ...p,
+        hits: 0,
+        runs: 0,
+        earnedRuns: 0,
+        strikeouts: 0,
+        walks: 0,
+        hitByPitch: 0,
+        homeRuns: 0,
+        battersFaced: 0,
+        inningStats: [
+          {
+            inning: 1,
+            runs: p.runs,
+            hits: p.hits,
+            strikeouts: p.strikeouts,
+            earnedRuns: p.earnedRuns,
+            walks: p.walks,
+            hitByPitch: p.hitByPitch,
+            homeRuns: p.homeRuns,
+            battersFaced: p.battersFaced ?? 0,
+          },
+        ],
+      }))
+      onPitchersChange(updated)
+    }
+    setInputMode(targetMode)
   }
 
-  const handleDelete = (index: number) => {
+  // ── 集約モード用ハンドラ ──
+  const handleAggAdd = () => {
+    setAggEditingIndex(null)
+    setAggForm({ ...EMPTY_PITCHER })
+    setIsAggDialogOpen(true)
+  }
+
+  const handleAggEdit = (index: number) => {
+    setAggEditingIndex(index)
+    setAggForm(pitchers[index])
+    setIsAggDialogOpen(true)
+  }
+
+  const handleAggDelete = (index: number) => {
     onPitchersChange(pitchers.filter((_, i) => i !== index))
   }
 
-  const handleSave = () => {
-    if (!form.playerName.trim()) return
-
-    if (editingIndex !== null) {
-      const newPitchers = [...pitchers]
-      newPitchers[editingIndex] = form
-      onPitchersChange(newPitchers)
+  const handleAggSave = () => {
+    if (!aggForm.playerName.trim()) return
+    if (aggEditingIndex !== null) {
+      const updated = [...pitchers]
+      updated[aggEditingIndex] = aggForm
+      onPitchersChange(updated)
     } else {
-      onPitchersChange([...pitchers, { ...form, playerId: form.playerId || "" }])
+      onPitchersChange([...pitchers, { ...aggForm, playerId: aggForm.playerId || "" }])
     }
-    setIsDialogOpen(false)
+    setIsAggDialogOpen(false)
   }
 
+  // ── イニングモード用ハンドラ ──
+  const handleInningAddPitcher = () => {
+    setPlayerEditingIndex(null)
+    setPlayerForm({ ...EMPTY_PITCHER, inningStats: [] })
+    setIsPlayerDialogOpen(true)
+  }
+
+  const handleInningEditPlayer = (index: number) => {
+    setPlayerEditingIndex(index)
+    setPlayerForm(pitchers[index])
+    setIsPlayerDialogOpen(true)
+  }
+
+  const handleInningDeletePitcher = (index: number) => {
+    onPitchersChange(pitchers.filter((_, i) => i !== index))
+  }
+
+  const handlePlayerSave = () => {
+    if (!playerForm.playerName.trim()) return
+    if (playerEditingIndex !== null) {
+      const updated = [...pitchers]
+      updated[playerEditingIndex] = { ...updated[playerEditingIndex], ...playerForm }
+      onPitchersChange(updated)
+    } else {
+      onPitchersChange([...pitchers, { ...playerForm, playerId: playerForm.playerId || "", inningStats: [] }])
+    }
+    setIsPlayerDialogOpen(false)
+  }
+
+  const handleInningCellClick = (pitcherIndex: number, inning: number) => {
+    setInningDialogPitcherIndex(pitcherIndex)
+    setInningDialogInning(inning)
+    const existing = pitchers[pitcherIndex].inningStats?.find(s => s.inning === inning)
+    setInningForm(existing ? { ...existing } : { ...EMPTY_INNING_STATS, inning })
+    setIsInningDialogOpen(true)
+  }
+
+  const handleInningStatsSave = () => {
+    const updated = [...pitchers]
+    const pitcher = { ...updated[inningDialogPitcherIndex] }
+    const stats = pitcher.inningStats ? [...pitcher.inningStats] : []
+    const existingIdx = stats.findIndex(s => s.inning === inningDialogInning)
+    const newStat = { ...inningForm, inning: inningDialogInning }
+    if (existingIdx >= 0) {
+      stats[existingIdx] = newStat
+    } else {
+      stats.push(newStat)
+      stats.sort((a, b) => a.inning - b.inning)
+    }
+    pitcher.inningStats = stats
+    updated[inningDialogPitcherIndex] = pitcher
+    onPitchersChange(updated)
+    setIsInningDialogOpen(false)
+  }
+
+  // ── 共通UIパーツ ──
   const StatButton = ({
     label,
     value,
     onChange,
     min = 0,
     max = 99,
-    step = 1,
   }: {
     label: string
     value: number
     onChange: (v: number) => void
     min?: number
     max?: number
-    step?: number
   }) => (
     <div className="flex items-center justify-between gap-2">
       <span className="text-sm font-medium text-slate-600 min-w-[60px]">{label}</span>
       <div className="flex items-center gap-1">
         <button
-          onClick={() => onChange(Math.max(min, value - step))}
+          onClick={() => onChange(Math.max(min, value - 1))}
           className="w-9 h-9 rounded-lg bg-slate-200 hover:bg-slate-300 text-slate-600 font-bold transition-colors flex items-center justify-center"
         >
           <Minus className="w-4 h-4" />
         </button>
-        <span className="w-10 text-center font-bold text-lg text-slate-800">
-          {value}
-        </span>
+        <span className="w-10 text-center font-bold text-lg text-slate-800">{value}</span>
         <button
-          onClick={() => onChange(Math.min(max, value + step))}
+          onClick={() => onChange(Math.min(max, value + 1))}
           className="w-9 h-9 rounded-lg bg-slate-200 hover:bg-slate-300 text-slate-600 font-bold transition-colors flex items-center justify-center"
         >
           <Plus className="w-4 h-4" />
@@ -165,273 +326,425 @@ export function PitcherInput({
     </button>
   )
 
-  return (
-    <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
-      <div className="px-4 py-3 bg-slate-50 border-b border-slate-200 flex items-center justify-between">
-        <h2 className="font-bold text-slate-700">投手成績</h2>
-        <Button size="sm" variant="outline" onClick={handleAdd} className="gap-1">
-          <Plus className="w-4 h-4" />
-          追加
-        </Button>
-      </div>
+  const PlayerNameSection = ({
+    form,
+    setForm,
+  }: {
+    form: PitcherResult
+    setForm: (f: PitcherResult) => void
+  }) => (
+    <div>
+      <label className="text-sm font-semibold text-slate-700 mb-2 block">選手名</label>
+      {!form.isHelper && (
+        registeredPlayers.length > 0 ? (
+          <select
+            value={form.playerId}
+            onChange={(e) => {
+              const player = registeredPlayers.find(p => p.id === e.target.value)
+              if (player) {
+                setForm({ ...form, playerId: player.id, playerName: player.name, isHelper: false })
+              }
+            }}
+            className="w-full h-12 px-4 rounded-xl border border-slate-200 bg-slate-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white transition-all text-slate-800"
+          >
+            <option value="">選手を選択</option>
+            {sortPlayersByNumber(registeredPlayers).map((player) => (
+              <option key={player.id} value={player.id}>
+                {player.number ? `${player.number} ` : ""}{player.name}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <input
+            type="text"
+            value={form.playerName}
+            onChange={(e) => setForm({ ...form, playerName: e.target.value })}
+            placeholder="選手名を入力"
+            className="w-full h-12 px-4 rounded-xl border border-slate-200 bg-slate-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white transition-all text-slate-800 placeholder:text-slate-400"
+          />
+        )
+      )}
+      <button
+        onClick={() => {
+          if (form.isHelper) {
+            setForm({ ...form, playerId: "", playerName: "", isHelper: false })
+          } else {
+            setForm({ ...form, playerId: "", playerName: "助っ人", isHelper: true })
+          }
+        }}
+        className={cn(
+          "mt-2 text-xs px-3 py-1.5 rounded-lg transition-all",
+          form.isHelper
+            ? "bg-purple-50 text-purple-600 border border-purple-300 font-medium"
+            : "text-slate-400 border border-dashed border-slate-300 hover:border-slate-400 hover:text-slate-500"
+        )}
+      >
+        {form.isHelper ? "✓ 助っ人" : "助っ人として登録"}
+      </button>
+    </div>
+  )
 
-      {pitchers.length === 0 ? (
-        <div className="p-8 text-center text-slate-400">
-          投手を追加してください
+  const InningsSection = ({
+    form,
+    setForm,
+  }: {
+    form: PitcherResult
+    setForm: (f: PitcherResult) => void
+  }) => (
+    <div className="flex justify-center py-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-medium text-slate-600 min-w-[60px]">投球回</span>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => {
+              const [o, m] = prevInnings(form.outsPitched, form.isMidInningExit)
+              setForm({ ...form, outsPitched: o, isMidInningExit: m })
+            }}
+            className="w-9 h-9 rounded-lg bg-slate-200 hover:bg-slate-300 text-slate-600 font-bold transition-colors flex items-center justify-center"
+          >
+            <Minus className="w-4 h-4" />
+          </button>
+          <span className="w-14 text-center font-bold text-lg text-slate-800">
+            {formatInnings(form.outsPitched, form.isMidInningExit)}
+          </span>
+          <button
+            onClick={() => {
+              const [o, m] = nextInnings(form.outsPitched, form.isMidInningExit)
+              setForm({ ...form, outsPitched: o, isMidInningExit: m })
+            }}
+            className="w-9 h-9 rounded-lg bg-slate-200 hover:bg-slate-300 text-slate-600 font-bold transition-colors flex items-center justify-center"
+          >
+            <Plus className="w-4 h-4" />
+          </button>
         </div>
-      ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[560px] text-sm">
-            <thead className="bg-slate-50 text-slate-600">
-              <tr>
-                <th className="px-2 py-2 text-center font-medium"></th>
-                <th className="px-3 py-2 text-left font-medium">投手</th>
-                <th className="px-2 py-2 text-center font-medium">回</th>
-                <th className="px-2 py-2 text-center font-medium">打者</th>
-                <th className="px-2 py-2 text-center font-medium">被安</th>
-                <th className="px-2 py-2 text-center font-medium">被本</th>
-                <th className="px-2 py-2 text-center font-medium">三振</th>
-                <th className="px-2 py-2 text-center font-medium">四球</th>
-                <th className="px-2 py-2 text-center font-medium">死球</th>
-                <th className="px-2 py-2 text-center font-medium">失点</th>
-                <th className="px-2 py-2 text-center font-medium">自責</th>
-                <th className="px-2 py-2 text-center font-medium"></th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-100">
-              {pitchers.map((pitcher, index) => (
-                <tr
-                  key={pitcher.playerId}
-                  className="hover:bg-slate-50 cursor-pointer transition-colors"
-                  onClick={() => handleEdit(index)}
-                >
-                  <td className="px-2 py-2 text-center">
-                    <div className="flex items-center justify-center gap-1">
-                      {pitcher.award === 'win'  && <span className="text-amber-500 font-bold">勝</span>}
-                      {pitcher.award === 'lose' && <span className="text-slate-500 font-bold">敗</span>}
-                      {pitcher.award === 'save' && <span className="text-blue-500 font-bold">S</span>}
-                      {pitcher.award === 'hold' && <span className="text-emerald-500 font-bold">H</span>}
-                    </div>
-                  </td>
-                  <td className="px-3 py-2 font-medium text-slate-800">
-                    <div className="flex items-center gap-1.5">
-                      {pitcher.playerName}
-                      {pitcher.isHelper && (
-                        <span className="text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-600 font-medium">助っ人</span>
+      </div>
+    </div>
+  )
+
+  const AwardSection = ({
+    form,
+    setForm,
+  }: {
+    form: PitcherResult
+    setForm: (f: PitcherResult) => void
+  }) => (
+    <div>
+      <label className="text-sm font-semibold text-slate-700 mb-3 block">勝敗・セーブ</label>
+      <div className="grid grid-cols-2 gap-3">
+        <DecisionButton label="勝利" icon={Trophy} active={form.award === "win"} onClick={() => setForm({ ...form, award: form.award === "win" ? null : "win" })} color="bg-amber-500" />
+        <DecisionButton label="敗戦" icon={ThumbsDown} active={form.award === "lose"} onClick={() => setForm({ ...form, award: form.award === "lose" ? null : "lose" })} color="bg-slate-500" />
+        <DecisionButton label="セーブ" icon={Shield} active={form.award === "save"} onClick={() => setForm({ ...form, award: form.award === "save" ? null : "save" })} color="bg-blue-500" />
+        <DecisionButton label="ホールド" icon={Star} active={form.award === "hold"} onClick={() => setForm({ ...form, award: form.award === "hold" ? null : "hold" })} color="bg-emerald-500" />
+      </div>
+    </div>
+  )
+
+  // ── イニングモード テーブル ──
+  const inningColumns = Array.from({ length: totalInnings }, (_, i) => i + 1)
+  const STAT_ROWS = ["失点", "安打", "三振"] as const
+
+  const getInningValue = (pitcher: PitcherResult, inning: number, stat: typeof STAT_ROWS[number]): number | null => {
+    const s = pitcher.inningStats?.find(x => x.inning === inning)
+    if (!s) return null
+    if (stat === "失点") return s.runs
+    if (stat === "安打") return s.hits
+    return s.strikeouts
+  }
+
+  const renderInningTable = () => (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm border-collapse">
+        <thead className="bg-slate-50 text-slate-600">
+          <tr>
+            <th className="px-2 py-2 text-center font-medium w-8">#</th>
+            <th className="px-3 py-2 text-left font-medium min-w-[5rem]">投手</th>
+            <th className="px-2 py-2 text-center font-medium w-10">項目</th>
+            {inningColumns.map(n => (
+              <th key={n} className="px-1 py-2 text-center font-medium w-8">{n}</th>
+            ))}
+            <th className="w-8"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {pitchers.map((pitcher, pIdx) => (
+            STAT_ROWS.map((stat, sIdx) => (
+              <tr key={`${pIdx}-${stat}`} className={cn("border-t border-slate-100", sIdx === 0 && pIdx > 0 && "border-t-2 border-slate-200")}>
+                {sIdx === 0 && (
+                  <>
+                    <td rowSpan={3} className="px-2 py-1 text-center text-slate-500 align-middle">
+                      {pIdx + 1}
+                    </td>
+                    <td
+                      rowSpan={3}
+                      className="px-3 py-1 align-middle cursor-pointer hover:bg-blue-50 transition-colors"
+                      onClick={() => handleInningEditPlayer(pIdx)}
+                    >
+                      <div className="flex flex-col gap-0.5">
+                        <div className="flex items-center gap-1">
+                          {pitcher.award === "win"  && <span className="text-xs text-amber-500 font-bold">勝</span>}
+                          {pitcher.award === "lose" && <span className="text-xs text-slate-500 font-bold">敗</span>}
+                          {pitcher.award === "save" && <span className="text-xs text-blue-500 font-bold">S</span>}
+                          {pitcher.award === "hold" && <span className="text-xs text-emerald-500 font-bold">H</span>}
+                          <span className="font-medium text-slate-800">{pitcher.playerName || <span className="text-slate-400">名前を設定</span>}</span>
+                          {pitcher.isHelper && <span className="text-xs px-1 rounded bg-purple-100 text-purple-600">助っ人</span>}
+                        </div>
+                        <span className="text-xs text-slate-400">{formatInnings(pitcher.outsPitched, pitcher.isMidInningExit)}</span>
+                      </div>
+                    </td>
+                  </>
+                )}
+                <td className="px-2 py-1 text-center text-xs text-slate-500 whitespace-nowrap">{stat}</td>
+                {inningColumns.map(inning => {
+                  const val = getInningValue(pitcher, inning, stat)
+                  return (
+                    <td
+                      key={inning}
+                      className="px-1 py-1 text-center cursor-pointer hover:bg-blue-50 transition-colors rounded"
+                      onClick={() => handleInningCellClick(pIdx, inning)}
+                    >
+                      {val !== null ? (
+                        <span className={cn("font-medium", val > 0 && stat === "失点" && "text-red-600")}>{val}</span>
+                      ) : (
+                        <span className="text-slate-200">-</span>
                       )}
-                    </div>
-                  </td>
-                  <td className="px-2 py-2 text-center">{formatInnings(pitcher.outsPitched, pitcher.isMidInningExit)}</td>
-                  <td className="px-2 py-2 text-center">{pitcher.battersFaced ?? 0}</td>
-                  <td className="px-2 py-2 text-center">{pitcher.hits}</td>
-                  <td className="px-2 py-2 text-center">{pitcher.homeRuns}</td>
-                  <td className="px-2 py-2 text-center">{pitcher.strikeouts}</td>
-                  <td className="px-2 py-2 text-center">{pitcher.walks}</td>
-                  <td className="px-2 py-2 text-center">{pitcher.hitByPitch}</td>
-                  <td className="px-2 py-2 text-center">{pitcher.runs}</td>
-                  <td className="px-2 py-2 text-center">{pitcher.earnedRuns}</td>
-                  <td className="px-2 py-2 text-center" onClick={(e) => e.stopPropagation()}>
+                    </td>
+                  )
+                })}
+                {sIdx === 0 && (
+                  <td rowSpan={3} className="px-1 py-1 text-center align-middle">
                     <button
-                      onClick={() => handleDelete(index)}
+                      onClick={() => handleInningDeletePitcher(pIdx)}
                       className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
                     >
                       <Trash2 className="w-4 h-4" />
                     </button>
                   </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                )}
+              </tr>
+            ))
+          ))}
+        </tbody>
+      </table>
+      <div className="px-4 py-2">
+        <button
+          onClick={handleInningAddPitcher}
+          className="text-sm text-blue-600 hover:text-blue-700 font-medium flex items-center gap-1 py-1"
+        >
+          <Plus className="w-4 h-4" />
+          投手を追加
+        </button>
+      </div>
+    </div>
+  )
+
+  // ── 集約モード テーブル（既存） ──
+  const renderAggregateTable = () => (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[560px] text-sm">
+        <thead className="bg-slate-50 text-slate-600">
+          <tr>
+            <th className="px-2 py-2 text-center font-medium"></th>
+            <th className="px-3 py-2 text-left font-medium">投手</th>
+            <th className="px-2 py-2 text-center font-medium">回</th>
+            <th className="px-2 py-2 text-center font-medium">打者</th>
+            <th className="px-2 py-2 text-center font-medium">被安</th>
+            <th className="px-2 py-2 text-center font-medium">被本</th>
+            <th className="px-2 py-2 text-center font-medium">三振</th>
+            <th className="px-2 py-2 text-center font-medium">四球</th>
+            <th className="px-2 py-2 text-center font-medium">死球</th>
+            <th className="px-2 py-2 text-center font-medium">失点</th>
+            <th className="px-2 py-2 text-center font-medium">自責</th>
+            <th className="px-2 py-2 text-center font-medium"></th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {pitchers.map((pitcher, index) => (
+            <tr
+              key={index}
+              className="hover:bg-slate-50 cursor-pointer transition-colors"
+              onClick={() => handleAggEdit(index)}
+            >
+              <td className="px-2 py-2 text-center">
+                {pitcher.award === "win"  && <span className="text-amber-500 font-bold">勝</span>}
+                {pitcher.award === "lose" && <span className="text-slate-500 font-bold">敗</span>}
+                {pitcher.award === "save" && <span className="text-blue-500 font-bold">S</span>}
+                {pitcher.award === "hold" && <span className="text-emerald-500 font-bold">H</span>}
+              </td>
+              <td className="px-3 py-2 font-medium text-slate-800">
+                <div className="flex items-center gap-1.5">
+                  {pitcher.playerName}
+                  {pitcher.isHelper && <span className="text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-600 font-medium">助っ人</span>}
+                </div>
+              </td>
+              <td className="px-2 py-2 text-center">{formatInnings(pitcher.outsPitched, pitcher.isMidInningExit)}</td>
+              <td className="px-2 py-2 text-center">{pitcher.battersFaced ?? 0}</td>
+              <td className="px-2 py-2 text-center">{pitcher.hits}</td>
+              <td className="px-2 py-2 text-center">{pitcher.homeRuns}</td>
+              <td className="px-2 py-2 text-center">{pitcher.strikeouts}</td>
+              <td className="px-2 py-2 text-center">{pitcher.walks}</td>
+              <td className="px-2 py-2 text-center">{pitcher.hitByPitch}</td>
+              <td className="px-2 py-2 text-center">{pitcher.runs}</td>
+              <td className="px-2 py-2 text-center">{pitcher.earnedRuns}</td>
+              <td className="px-2 py-2 text-center" onClick={(e) => e.stopPropagation()}>
+                <button
+                  onClick={() => handleAggDelete(index)}
+                  className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-slate-200 overflow-hidden">
+      {/* ヘッダ */}
+      <div className="px-4 py-3 bg-slate-50 border-b border-slate-200 flex items-center justify-between gap-2">
+        <h2 className="font-bold text-slate-700">投手成績</h2>
+        <div className="flex items-center gap-2">
+          {/* モードトグル */}
+          <div className="flex rounded-lg border border-slate-200 overflow-hidden text-xs font-medium">
+            <button
+              onClick={() => handleModeToggle("inning")}
+              className={cn(
+                "px-3 py-1.5 transition-colors",
+                inputMode === "inning"
+                  ? "bg-blue-600 text-white"
+                  : "bg-white text-slate-600 hover:bg-slate-50"
+              )}
+            >
+              イニングごと
+            </button>
+            <button
+              onClick={() => handleModeToggle("aggregate")}
+              className={cn(
+                "px-3 py-1.5 transition-colors",
+                inputMode === "aggregate"
+                  ? "bg-blue-600 text-white"
+                  : "bg-white text-slate-600 hover:bg-slate-50"
+              )}
+            >
+              試合集約
+            </button>
+          </div>
+          {inputMode === "aggregate" && (
+            <Button size="sm" variant="outline" onClick={handleAggAdd} className="gap-1">
+              <Plus className="w-4 h-4" />
+              追加
+            </Button>
+          )}
         </div>
+      </div>
+
+      {/* テーブル */}
+      {pitchers.length === 0 && inputMode === "aggregate" ? (
+        <div className="p-8 text-center text-slate-400">投手を追加してください</div>
+      ) : inputMode === "inning" ? (
+        renderInningTable()
+      ) : (
+        renderAggregateTable()
       )}
 
-      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      {/* ── 確認ダイアログ ── */}
+      <Dialog open={confirmDialog.open} onOpenChange={(open) => !open && setConfirmDialog(prev => ({ ...prev, open: false }))}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="text-base font-bold text-slate-800">入力モードの切り替え</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-slate-600 py-2">
+            {confirmDialog.targetMode === "aggregate"
+              ? "イニングごとのデータは集約されますがよろしいですか？"
+              : "入力されたデータは1回の記録とします"}
+          </p>
+          <div className="flex gap-3 pt-2">
+            <Button variant="outline" className="flex-1" onClick={() => setConfirmDialog(prev => ({ ...prev, open: false }))}>
+              キャンセル
+            </Button>
+            <Button className="flex-1 bg-blue-600 hover:bg-blue-700 text-white" onClick={handleConfirmModeSwitch}>
+              OK
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── 集約モード: 投手編集ダイアログ ── */}
+      <Dialog open={isAggDialogOpen} onOpenChange={setIsAggDialogOpen}>
         <DialogContent className="max-w-lg max-h-[90svh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="text-lg font-bold text-slate-800">
-              {editingIndex !== null ? "投手成績を編集" : "投手を追加"}
+              {aggEditingIndex !== null ? "投手成績を編集" : "投手を追加"}
             </DialogTitle>
           </DialogHeader>
-
           <div className="space-y-6 py-4">
-            {/* 選手名 */}
-            <div>
-              <label className="text-sm font-semibold text-slate-700 mb-2 block">選手名</label>
-              {!form.isHelper && (
-                registeredPlayers.length > 0 ? (
-                  <select
-                    value={form.playerId}
-                    onChange={(e) => {
-                      const player = registeredPlayers.find(p => p.id === e.target.value)
-                      if (player) {
-                        setForm({ ...form, playerId: player.id, playerName: player.name, isHelper: false })
-                      }
-                    }}
-                    className="w-full h-12 px-4 rounded-xl border border-slate-200 bg-slate-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white transition-all text-slate-800"
-                  >
-                    <option value="">選手を選択</option>
-                    {sortPlayersByNumber(registeredPlayers).map((player) => (
-                      <option key={player.id} value={player.id}>
-                        {player.number ? `${player.number} ` : ""}{player.name}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  <input
-                    type="text"
-                    value={form.playerName}
-                    onChange={(e) => setForm({ ...form, playerName: e.target.value })}
-                    placeholder="選手名を入力"
-                    className="w-full h-12 px-4 rounded-xl border border-slate-200 bg-slate-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white transition-all text-slate-800 placeholder:text-slate-400"
-                  />
-                )
-              )}
-              <button
-                onClick={() => {
-                  if (form.isHelper) {
-                    setForm({ ...form, playerId: "", playerName: "", isHelper: false })
-                  } else {
-                    setForm({ ...form, playerId: "", playerName: "助っ人", isHelper: true })
-                  }
-                }}
-                className={cn(
-                  "mt-2 text-xs px-3 py-1.5 rounded-lg transition-all",
-                  form.isHelper
-                    ? "bg-purple-50 text-purple-600 border border-purple-300 font-medium"
-                    : "text-slate-400 border border-dashed border-slate-300 hover:border-slate-400 hover:text-slate-500"
-                )}
-              >
-                {form.isHelper ? "✓ 助っ人" : "助っ人として登録"}
-              </button>
-            </div>
-
-            {/* 投球回 */}
-            <div className="flex justify-center py-2">
-              <div className="flex items-center justify-between gap-2">
-                <span className="text-sm font-medium text-slate-600 min-w-[60px]">投球回</span>
-                <div className="flex items-center gap-1">
-                  <button
-                    onClick={() => {
-                      const [o, m] = prevInnings(form.outsPitched, form.isMidInningExit)
-                      setForm({ ...form, outsPitched: o, isMidInningExit: m })
-                    }}
-                    className="w-9 h-9 rounded-lg bg-slate-200 hover:bg-slate-300 text-slate-600 font-bold transition-colors flex items-center justify-center"
-                  >
-                    <Minus className="w-4 h-4" />
-                  </button>
-                  <span className="w-14 text-center font-bold text-lg text-slate-800">
-                    {formatInnings(form.outsPitched, form.isMidInningExit)}
-                  </span>
-                  <button
-                    onClick={() => {
-                      const [o, m] = nextInnings(form.outsPitched, form.isMidInningExit)
-                      setForm({ ...form, outsPitched: o, isMidInningExit: m })
-                    }}
-                    className="w-9 h-9 rounded-lg bg-slate-200 hover:bg-slate-300 text-slate-600 font-bold transition-colors flex items-center justify-center"
-                  >
-                    <Plus className="w-4 h-4" />
-                  </button>
-                </div>
-              </div>
-            </div>
-
-            {/* スタッツ - 2列 */}
+            <PlayerNameSection form={aggForm} setForm={setAggForm} />
+            <InningsSection form={aggForm} setForm={setAggForm} />
             <div className="bg-slate-50 rounded-xl p-4">
               <div className="grid grid-cols-1 gap-y-3 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-4">
-                <StatButton
-                  label="打者"
-                  value={form.battersFaced ?? 0}
-                  onChange={(v) => setForm({ ...form, battersFaced: v })}
-                />
-                <StatButton
-                  label="被安打"
-                  value={form.hits}
-                  onChange={(v) => setForm({ ...form, hits: v })}
-                />
-                <StatButton
-                  label="被本塁打"
-                  value={form.homeRuns}
-                  onChange={(v) => setForm({ ...form, homeRuns: v })}
-                />
-                <StatButton
-                  label="奪三振"
-                  value={form.strikeouts}
-                  onChange={(v) => setForm({ ...form, strikeouts: v })}
-                />
-                <StatButton
-                  label="四球"
-                  value={form.walks}
-                  onChange={(v) => setForm({ ...form, walks: v })}
-                />
-                <StatButton
-                  label="死球"
-                  value={form.hitByPitch}
-                  onChange={(v) => setForm({ ...form, hitByPitch: v })}
-                />
-                <StatButton
-                  label="失点"
-                  value={form.runs}
-                  onChange={(v) => setForm({ ...form, runs: v })}
-                />
-                <StatButton
-                  label="自責点"
-                  value={form.earnedRuns}
-                  onChange={(v) => setForm({ ...form, earnedRuns: v })}
-                />
+                <StatButton label="打者" value={aggForm.battersFaced ?? 0} onChange={(v) => setAggForm({ ...aggForm, battersFaced: v })} />
+                <StatButton label="被安打" value={aggForm.hits} onChange={(v) => setAggForm({ ...aggForm, hits: v })} />
+                <StatButton label="被本塁打" value={aggForm.homeRuns} onChange={(v) => setAggForm({ ...aggForm, homeRuns: v })} />
+                <StatButton label="奪三振" value={aggForm.strikeouts} onChange={(v) => setAggForm({ ...aggForm, strikeouts: v })} />
+                <StatButton label="四球" value={aggForm.walks} onChange={(v) => setAggForm({ ...aggForm, walks: v })} />
+                <StatButton label="死球" value={aggForm.hitByPitch} onChange={(v) => setAggForm({ ...aggForm, hitByPitch: v })} />
+                <StatButton label="失点" value={aggForm.runs} onChange={(v) => setAggForm({ ...aggForm, runs: v })} />
+                <StatButton label="自責点" value={aggForm.earnedRuns} onChange={(v) => setAggForm({ ...aggForm, earnedRuns: v })} />
               </div>
             </div>
-
-            {/* 勝敗セーブ */}
-            <div>
-              <label className="text-sm font-semibold text-slate-700 mb-3 block">勝敗・セーブ</label>
-              <div className="grid grid-cols-2 gap-3">
-                <DecisionButton
-                  label="勝利"
-                  icon={Trophy}
-                  active={form.award === 'win'}
-                  onClick={() => setForm({ ...form, award: form.award === 'win' ? null : 'win' })}
-                  color="bg-amber-500"
-                />
-                <DecisionButton
-                  label="敗戦"
-                  icon={ThumbsDown}
-                  active={form.award === 'lose'}
-                  onClick={() => setForm({ ...form, award: form.award === 'lose' ? null : 'lose' })}
-                  color="bg-slate-500"
-                />
-                <DecisionButton
-                  label="セーブ"
-                  icon={Shield}
-                  active={form.award === 'save'}
-                  onClick={() => setForm({ ...form, award: form.award === 'save' ? null : 'save' })}
-                  color="bg-blue-500"
-                />
-                <DecisionButton
-                  label="ホールド"
-                  icon={Star}
-                  active={form.award === 'hold'}
-                  onClick={() => setForm({ ...form, award: form.award === 'hold' ? null : 'hold' })}
-                  color="bg-emerald-500"
-                />
-              </div>
-            </div>
-
-            {/* ボタン */}
+            <AwardSection form={aggForm} setForm={setAggForm} />
             <div className="flex gap-3 pt-2">
-              <Button
-                variant="outline"
-                className="flex-1 h-12 rounded-xl text-slate-600"
-                onClick={() => setIsDialogOpen(false)}
-              >
-                キャンセル
-              </Button>
-              <Button
-                className="flex-1 h-12 rounded-xl bg-blue-600 hover:bg-blue-700 text-white font-semibold"
-                onClick={handleSave}
-                disabled={!form.playerName.trim()}
-              >
-                保存
-              </Button>
+              <Button variant="outline" className="flex-1 h-12 rounded-xl" onClick={() => setIsAggDialogOpen(false)}>キャンセル</Button>
+              <Button className="flex-1 h-12 rounded-xl bg-blue-600 hover:bg-blue-700 text-white font-semibold" onClick={handleAggSave} disabled={!aggForm.playerName.trim()}>保存</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── イニングモード: 選手編集ダイアログ ── */}
+      <Dialog open={isPlayerDialogOpen} onOpenChange={setIsPlayerDialogOpen}>
+        <DialogContent className="max-w-lg max-h-[90svh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="text-lg font-bold text-slate-800">
+              {playerEditingIndex !== null ? "投手を編集" : "投手を追加"}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-6 py-4">
+            <PlayerNameSection form={playerForm} setForm={setPlayerForm} />
+            <InningsSection form={playerForm} setForm={setPlayerForm} />
+            <AwardSection form={playerForm} setForm={setPlayerForm} />
+            <div className="flex gap-3 pt-2">
+              <Button variant="outline" className="flex-1 h-12 rounded-xl" onClick={() => setIsPlayerDialogOpen(false)}>キャンセル</Button>
+              <Button className="flex-1 h-12 rounded-xl bg-blue-600 hover:bg-blue-700 text-white font-semibold" onClick={handlePlayerSave} disabled={!playerForm.playerName.trim()}>保存</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── イニングモード: イニング統計ダイアログ ── */}
+      <Dialog open={isInningDialogOpen} onOpenChange={setIsInningDialogOpen}>
+        <DialogContent className="max-w-sm max-h-[90svh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="text-lg font-bold text-slate-800">
+              {pitchers[inningDialogPitcherIndex]?.playerName} — {inningDialogInning}回
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="bg-slate-50 rounded-xl p-4 space-y-3">
+              <StatButton label="失点" value={inningForm.runs} onChange={(v) => setInningForm({ ...inningForm, runs: v })} />
+              <StatButton label="自責点" value={inningForm.earnedRuns} onChange={(v) => setInningForm({ ...inningForm, earnedRuns: v })} />
+              <StatButton label="安打" value={inningForm.hits} onChange={(v) => setInningForm({ ...inningForm, hits: v })} />
+              <StatButton label="三振" value={inningForm.strikeouts} onChange={(v) => setInningForm({ ...inningForm, strikeouts: v })} />
+              <StatButton label="四球" value={inningForm.walks} onChange={(v) => setInningForm({ ...inningForm, walks: v })} />
+              <StatButton label="死球" value={inningForm.hitByPitch} onChange={(v) => setInningForm({ ...inningForm, hitByPitch: v })} />
+              <StatButton label="被本塁打" value={inningForm.homeRuns} onChange={(v) => setInningForm({ ...inningForm, homeRuns: v })} />
+              <StatButton label="打者数" value={inningForm.battersFaced} onChange={(v) => setInningForm({ ...inningForm, battersFaced: v })} />
+            </div>
+            <div className="flex gap-3">
+              <Button variant="outline" className="flex-1 h-12 rounded-xl" onClick={() => setIsInningDialogOpen(false)}>キャンセル</Button>
+              <Button className="flex-1 h-12 rounded-xl bg-blue-600 hover:bg-blue-700 text-white font-semibold" onClick={handleInningStatsSave}>保存</Button>
             </div>
           </div>
         </DialogContent>

--- a/components/pitcher-input.tsx
+++ b/components/pitcher-input.tsx
@@ -58,6 +58,7 @@ const EMPTY_PITCHER: PitcherResult = {
 
 const EMPTY_INNING_STATS: PitcherInningStats = {
   inning: 0,
+  outs: 3,
   runs: 0,
   hits: 0,
   strikeouts: 0,
@@ -68,8 +69,15 @@ const EMPTY_INNING_STATS: PitcherInningStats = {
   battersFaced: 0,
 }
 
-function sumInningStats(inningStats: PitcherInningStats[]): Pick<PitcherResult, "hits" | "runs" | "earnedRuns" | "strikeouts" | "walks" | "hitByPitch" | "homeRuns" | "battersFaced"> {
-  return inningStats.reduce(
+const OUTS_OPTIONS = [
+  { outs: 0, label: "0/3" },
+  { outs: 1, label: "1/3" },
+  { outs: 2, label: "2/3" },
+  { outs: 3, label: "1回" },
+] as const
+
+function sumInningStats(inningStats: PitcherInningStats[]): Pick<PitcherResult, "hits" | "runs" | "earnedRuns" | "strikeouts" | "walks" | "hitByPitch" | "homeRuns" | "battersFaced" | "outsPitched" | "isMidInningExit"> {
+  const totals = inningStats.reduce(
     (acc, s) => ({
       hits: acc.hits + s.hits,
       runs: acc.runs + s.runs,
@@ -79,9 +87,12 @@ function sumInningStats(inningStats: PitcherInningStats[]): Pick<PitcherResult, 
       hitByPitch: acc.hitByPitch + s.hitByPitch,
       homeRuns: acc.homeRuns + s.homeRuns,
       battersFaced: acc.battersFaced + s.battersFaced,
+      outsPitched: acc.outsPitched + (s.outs ?? 3),
     }),
-    { hits: 0, runs: 0, earnedRuns: 0, strikeouts: 0, walks: 0, hitByPitch: 0, homeRuns: 0, battersFaced: 0 }
+    { hits: 0, runs: 0, earnedRuns: 0, strikeouts: 0, walks: 0, hitByPitch: 0, homeRuns: 0, battersFaced: 0, outsPitched: 0 }
   )
+  const lastInning = inningStats[inningStats.length - 1]
+  return { ...totals, isMidInningExit: lastInning ? (lastInning.outs ?? 3) < 3 : false }
 }
 
 export function PitcherInput({
@@ -154,6 +165,8 @@ export function PitcherInput({
       // 集約 → イニング: aggregate フィールド → inning=1 のデータに変換、aggregate フィールドをリセット
       const updated = pitchers.map(p => ({
         ...p,
+        outsPitched: 0,
+        isMidInningExit: false,
         hits: 0,
         runs: 0,
         earnedRuns: 0,
@@ -165,6 +178,7 @@ export function PitcherInput({
         inningStats: [
           {
             inning: 1,
+            outs: 3,
             runs: p.runs,
             hits: p.hits,
             strikeouts: p.strikeouts,
@@ -260,6 +274,10 @@ export function PitcherInput({
       stats.sort((a, b) => a.inning - b.inning)
     }
     pitcher.inningStats = stats
+    // outsPitched / isMidInningExit をイニングデータから再計算
+    const agg = sumInningStats(stats)
+    pitcher.outsPitched = agg.outsPitched
+    pitcher.isMidInningExit = agg.isMidInningExit
     updated[inningDialogPitcherIndex] = pitcher
     onPitchersChange(updated)
     setIsInningDialogOpen(false)
@@ -457,7 +475,7 @@ export function PitcherInput({
         <thead className="bg-slate-50 text-slate-600">
           <tr>
             <th className="px-2 py-2 text-center font-medium w-8">#</th>
-            <th className="px-3 py-2 text-left font-medium min-w-[5rem]">投手</th>
+            <th className="px-2 py-2 text-left font-medium min-w-[4rem] max-w-[5rem]">投手</th>
             <th className="px-2 py-2 text-center font-medium w-10">項目</th>
             {inningColumns.map(n => (
               <th key={n} className="px-1 py-2 text-center font-medium w-8">{n}</th>
@@ -570,9 +588,9 @@ export function PitcherInput({
                 {pitcher.award === "save" && <span className="text-blue-500 font-bold">S</span>}
                 {pitcher.award === "hold" && <span className="text-emerald-500 font-bold">H</span>}
               </td>
-              <td className="px-3 py-2 font-medium text-slate-800">
-                <div className="flex items-center gap-1.5">
-                  {pitcher.playerName}
+              <td className="px-2 py-2 font-medium text-slate-800 min-w-[4rem] max-w-[5rem]">
+                <div className="flex items-center gap-1 flex-wrap">
+                  <span>{pitcher.playerName}</span>
                   {pitcher.isHelper && <span className="text-xs px-1.5 py-0.5 rounded bg-purple-100 text-purple-600 font-medium">助っ人</span>}
                 </div>
               </td>
@@ -685,13 +703,13 @@ export function PitcherInput({
             <div className="bg-slate-50 rounded-xl p-4">
               <div className="grid grid-cols-1 gap-y-3 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-4">
                 <StatButton label="打者" value={aggForm.battersFaced ?? 0} onChange={(v) => setAggForm({ ...aggForm, battersFaced: v })} />
+                <StatButton label="失点" value={aggForm.runs} onChange={(v) => setAggForm({ ...aggForm, runs: v })} />
                 <StatButton label="被安打" value={aggForm.hits} onChange={(v) => setAggForm({ ...aggForm, hits: v })} />
-                <StatButton label="被本塁打" value={aggForm.homeRuns} onChange={(v) => setAggForm({ ...aggForm, homeRuns: v })} />
                 <StatButton label="奪三振" value={aggForm.strikeouts} onChange={(v) => setAggForm({ ...aggForm, strikeouts: v })} />
                 <StatButton label="四球" value={aggForm.walks} onChange={(v) => setAggForm({ ...aggForm, walks: v })} />
                 <StatButton label="死球" value={aggForm.hitByPitch} onChange={(v) => setAggForm({ ...aggForm, hitByPitch: v })} />
-                <StatButton label="失点" value={aggForm.runs} onChange={(v) => setAggForm({ ...aggForm, runs: v })} />
                 <StatButton label="自責点" value={aggForm.earnedRuns} onChange={(v) => setAggForm({ ...aggForm, earnedRuns: v })} />
+                <StatButton label="被本塁打" value={aggForm.homeRuns} onChange={(v) => setAggForm({ ...aggForm, homeRuns: v })} />
               </div>
             </div>
             <AwardSection form={aggForm} setForm={setAggForm} />
@@ -713,11 +731,10 @@ export function PitcherInput({
           </DialogHeader>
           <div className="space-y-6 py-4">
             <PlayerNameSection form={playerForm} setForm={setPlayerForm} />
-            <InningsSection form={playerForm} setForm={setPlayerForm} />
             <AwardSection form={playerForm} setForm={setPlayerForm} />
             <div className="flex gap-3 pt-2">
               <Button variant="outline" className="flex-1 h-12 rounded-xl" onClick={() => setIsPlayerDialogOpen(false)}>キャンセル</Button>
-              <Button className="flex-1 h-12 rounded-xl bg-blue-600 hover:bg-blue-700 text-white font-semibold" onClick={handlePlayerSave} disabled={!playerForm.playerName.trim()}>保存</Button>
+              <Button className="flex-1 h-12 rounded-xl bg-blue-600 hover:bg-blue-700 text-white font-semibold" onClick={handlePlayerSave} disabled={!playerForm.playerName.trim() && !playerForm.isHelper}>保存</Button>
             </div>
           </div>
         </DialogContent>
@@ -732,15 +749,36 @@ export function PitcherInput({
             </DialogTitle>
           </DialogHeader>
           <div className="space-y-4 py-4">
+            {/* 投球回 */}
+            <div>
+              <label className="text-sm font-semibold text-slate-700 mb-2 block">投球回</label>
+              <div className="flex gap-2">
+                {OUTS_OPTIONS.map(opt => (
+                  <button
+                    key={opt.outs}
+                    onClick={() => setInningForm({ ...inningForm, outs: opt.outs })}
+                    className={cn(
+                      "flex-1 py-2.5 rounded-xl text-sm font-semibold transition-all border",
+                      inningForm.outs === opt.outs
+                        ? "bg-blue-600 text-white border-blue-600 shadow"
+                        : "bg-white text-slate-600 border-slate-200 hover:border-slate-300"
+                    )}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {/* スタッツ */}
             <div className="bg-slate-50 rounded-xl p-4 space-y-3">
+              <StatButton label="打者数" value={inningForm.battersFaced} onChange={(v) => setInningForm({ ...inningForm, battersFaced: v })} />
               <StatButton label="失点" value={inningForm.runs} onChange={(v) => setInningForm({ ...inningForm, runs: v })} />
-              <StatButton label="自責点" value={inningForm.earnedRuns} onChange={(v) => setInningForm({ ...inningForm, earnedRuns: v })} />
               <StatButton label="安打" value={inningForm.hits} onChange={(v) => setInningForm({ ...inningForm, hits: v })} />
               <StatButton label="三振" value={inningForm.strikeouts} onChange={(v) => setInningForm({ ...inningForm, strikeouts: v })} />
               <StatButton label="四球" value={inningForm.walks} onChange={(v) => setInningForm({ ...inningForm, walks: v })} />
               <StatButton label="死球" value={inningForm.hitByPitch} onChange={(v) => setInningForm({ ...inningForm, hitByPitch: v })} />
+              <StatButton label="自責点" value={inningForm.earnedRuns} onChange={(v) => setInningForm({ ...inningForm, earnedRuns: v })} />
               <StatButton label="被本塁打" value={inningForm.homeRuns} onChange={(v) => setInningForm({ ...inningForm, homeRuns: v })} />
-              <StatButton label="打者数" value={inningForm.battersFaced} onChange={(v) => setInningForm({ ...inningForm, battersFaced: v })} />
             </div>
             <div className="flex gap-3">
               <Button variant="outline" className="flex-1 h-12 rounded-xl" onClick={() => setIsInningDialogOpen(false)}>キャンセル</Button>

--- a/lib/batting-types.ts
+++ b/lib/batting-types.ts
@@ -118,23 +118,37 @@ export interface InningScore {
 
 export type PitcherAward = 'win' | 'lose' | 'save' | 'hold'
 
+// イニングごとの投手成績
+export interface PitcherInningStats {
+  inning: number
+  runs: number
+  hits: number
+  strikeouts: number
+  earnedRuns: number
+  walks: number
+  hitByPitch: number
+  homeRuns: number
+  battersFaced: number
+}
+
 // 投手成績
 export interface PitcherResult {
   playerId: string
   playerName: string
   outsPitched: number         // 投球アウト数（投球回 × 3）
   isMidInningExit: boolean    // イニング途中0アウト降板フラグ
-  hits: number                // 被安打
-  runs: number                // 失点
-  earnedRuns: number          // 自責点
-  strikeouts: number          // 奪三振
-  walks: number               // 与四球
-  hitByPitch: number          // 与死球
-  homeRuns: number            // 被本塁打
-  battersFaced?: number       // 対戦打者数
+  hits: number                // 被安打（集約モード）
+  runs: number                // 失点（集約モード）
+  earnedRuns: number          // 自責点（集約モード）
+  strikeouts: number          // 奪三振（集約モード）
+  walks: number               // 与四球（集約モード）
+  hitByPitch: number          // 与死球（集約モード）
+  homeRuns: number            // 被本塁打（集約モード）
+  battersFaced?: number       // 対戦打者数（集約モード）
   pitchCount?: number         // 球数
   award?: PitcherAward | null // 勝利・敗戦・セーブ・ホールド（排他）
   isHelper?: boolean          // 助っ人（個人成績に含めない）
+  inningStats?: PitcherInningStats[] // イニングごとの成績（イニングモード）
 }
 
 // 結果の短縮表示を生成

--- a/lib/batting-types.ts
+++ b/lib/batting-types.ts
@@ -121,6 +121,7 @@ export type PitcherAward = 'win' | 'lose' | 'save' | 'hold'
 // イニングごとの投手成績
 export interface PitcherInningStats {
   inning: number
+  outs: number        // 0, 1, 2, or 3 outs pitched in this inning (default 3 = 1回)
   runs: number
   hits: number
   strikeouts: number

--- a/scripts/006_pitcher_inning_stats.sql
+++ b/scripts/006_pitcher_inning_stats.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS pitcher_inning_stats (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  pitcher_result_id UUID NOT NULL REFERENCES pitcher_results(id) ON DELETE CASCADE,
+  inning INTEGER NOT NULL,
+  runs INTEGER NOT NULL DEFAULT 0,
+  hits INTEGER NOT NULL DEFAULT 0,
+  strikeouts INTEGER NOT NULL DEFAULT 0,
+  earned_runs INTEGER NOT NULL DEFAULT 0,
+  walks INTEGER NOT NULL DEFAULT 0,
+  hit_by_pitch INTEGER NOT NULL DEFAULT 0,
+  home_runs INTEGER NOT NULL DEFAULT 0,
+  batters_faced INTEGER NOT NULL DEFAULT 0,
+  UNIQUE(pitcher_result_id, inning)
+);

--- a/scripts/006_pitcher_inning_stats.sql
+++ b/scripts/006_pitcher_inning_stats.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS pitcher_inning_stats (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   pitcher_result_id UUID NOT NULL REFERENCES pitcher_results(id) ON DELETE CASCADE,
   inning INTEGER NOT NULL,
+  outs INTEGER NOT NULL DEFAULT 3,
   runs INTEGER NOT NULL DEFAULT 0,
   hits INTEGER NOT NULL DEFAULT 0,
   strikeouts INTEGER NOT NULL DEFAULT 0,
@@ -12,3 +13,4 @@ CREATE TABLE IF NOT EXISTS pitcher_inning_stats (
   batters_faced INTEGER NOT NULL DEFAULT 0,
   UNIQUE(pitcher_result_id, inning)
 );
+ALTER TABLE pitcher_inning_stats ADD COLUMN IF NOT EXISTS outs INTEGER NOT NULL DEFAULT 3;


### PR DESCRIPTION
- pitcher_inning_stats テーブルを追加（新規SQL: 006_pitcher_inning_stats.sql）
- PitcherInningStats 型を lib/batting-types.ts に追加
- PitcherResult に inningStats フィールドを追加
- pitcher-input.tsx をイニングモード/集約モードの切り替えに対応
  - イニングモードがデフォルト（テーブルで失点・安打・三振をイニングごと表示）
  - 名前セルクリック→PlayerEditDialog（選手・投球回・勝敗設定）
  - イニングセルクリック→InningStatsDialog（イニングごとの成績入力）
  - 両方向の切り替えに確認ダイアログを表示
- 試合結果画面に試合合計/イニングごとのトグルを追加（PitcherResultsSection）
- stats ページの集計でイニングデータを優先使用するように修正
- GET API でイニングデータを pitcher_results に付与
- 投手保存 API で pitcher_inning_stats の保存/削除に対応

https://claude.ai/code/session_0191Cwc5SURQqHSrkFwDjEPg