### PR TITLE
feat: 現在入力中のイニングをハイライト表示

### DIFF
--- a/components/batting-grid.tsx
+++ b/components/batting-grid.tsx
@@ -17,6 +17,7 @@ interface BattingGridProps {
   atBatSequences: Record<number, number>
   onAddAtBat: (inning: number) => void
   onRemoveAtBat: (inning: number) => void
+  activeInning?: number | null
 }
 
 export function BattingGrid({
@@ -29,6 +30,7 @@ export function BattingGrid({
   atBatSequences,
   onAddAtBat,
   onRemoveAtBat,
+  activeInning,
 }: BattingGridProps) {
   const maxBattingOrder = Math.max(lineupSlots.length, 9)
   const battingOrders = Array.from({ length: maxBattingOrder }, (_, i) => i + 1)
@@ -101,9 +103,10 @@ export function BattingGrid({
                   <th
                     key={`${col.inning}-${col.sequence}`}
                     className={cn(
-                      "px-1 py-1 text-center text-xs font-semibold",
+                      "px-1 py-1 text-center text-xs font-semibold transition-colors",
                       col.sequence === 1 ? "w-12 min-w-[48px]" : "w-10 min-w-[40px]",
-                      isLastOfInning && "border-r border-slate-200"
+                      isLastOfInning && "border-r border-slate-200",
+                      col.inning === activeInning && "bg-amber-100 text-amber-800"
                     )}
                   >
                     {col.sequence === 1 ? (
@@ -180,7 +183,11 @@ export function BattingGrid({
                     return (
                       <td
                         key={`${col.inning}-${col.sequence}`}
-                        className={cn("p-1", isLastOfInning && "border-r border-slate-100")}
+                        className={cn(
+                          "p-1 transition-colors",
+                          isLastOfInning && "border-r border-slate-100",
+                          col.inning === activeInning && "bg-amber-50"
+                        )}
                       >
                         <button
                           onClick={() => onCellClick({ battingOrder: order, inning: col.inning, atBatSequence: col.sequence })}

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -77,6 +77,9 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack, player
   // 投手成績
   const [pitchers, setPitchers] = useState<PitcherResult[]>([])
 
+  // 現在入力中のイニング（ハイライト用）
+  const [activeInning, setActiveInning] = useState<number | null>(null)
+
   // 共有URL関連
   const [shareDialogOpen, setShareDialogOpen] = useState(false)
   const [generatedShareToken, setGeneratedShareToken] = useState<string | null>(null)
@@ -449,6 +452,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack, player
   }, [apiRequest, gameId])
 
   const handleCellClick = (position: CellPosition) => {
+    setActiveInning(position.inning)
     setSelectedCell(position)
     setDialogOpen(true)
   }
@@ -670,6 +674,8 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack, player
           hasX={hasX}
           xScore={xScore}
           onXChange={handleXChange}
+          activeInning={activeInning}
+          onInningFocus={setActiveInning}
           onTotalInningsChange={(value) => {
             handleGameInfoChange("totalInnings", value)
             // イニングスコア配列も調整
@@ -696,6 +702,7 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack, player
           atBatSequences={atBatSequences}
           onAddAtBat={handleAddAtBat}
           onRemoveAtBat={handleRemoveAtBat}
+          activeInning={activeInning}
         />
 
         <PitcherInput
@@ -703,6 +710,8 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack, player
           onPitchersChange={handlePitchersChange}
           registeredPlayers={registeredPlayers}
           totalInnings={totalInnings}
+          activeInning={activeInning}
+          onInningFocus={setActiveInning}
         />
       </div>
 

--- a/components/pitcher-input.tsx
+++ b/components/pitcher-input.tsx
@@ -13,6 +13,8 @@ interface PitcherInputProps {
   onPitchersChange: (pitchers: PitcherResult[]) => void
   registeredPlayers?: Player[]
   totalInnings?: number
+  activeInning?: number | null
+  onInningFocus?: (inning: number) => void
 }
 
 export function formatInnings(outs: number, isMidInningExit: boolean): string {
@@ -100,6 +102,8 @@ export function PitcherInput({
   onPitchersChange,
   registeredPlayers = [],
   totalInnings = 9,
+  activeInning,
+  onInningFocus,
 }: PitcherInputProps) {
   const [inputMode, setInputMode] = useState<InputMode>("inning")
   const [confirmDialog, setConfirmDialog] = useState<{ open: boolean; targetMode: InputMode }>({ open: false, targetMode: "aggregate" })
@@ -254,6 +258,7 @@ export function PitcherInput({
   }
 
   const handleInningCellClick = (pitcherIndex: number, inning: number) => {
+    onInningFocus?.(inning)
     setInningDialogPitcherIndex(pitcherIndex)
     setInningDialogInning(inning)
     const existing = pitchers[pitcherIndex].inningStats?.find(s => s.inning === inning)
@@ -491,7 +496,7 @@ export function PitcherInput({
             <th className="px-2 py-2 text-left font-medium min-w-[4rem] max-w-[5rem]">投手</th>
             <th className="px-2 py-2 text-center font-medium w-10">項目</th>
             {inningColumns.map(n => (
-              <th key={n} className="px-1 py-2 text-center font-medium w-8">{n}</th>
+              <th key={n} className={cn("px-1 py-2 text-center font-medium w-8 transition-colors", n === activeInning && "bg-amber-100 text-amber-800")}>{n}</th>
             ))}
             <th className="w-8"></th>
           </tr>
@@ -527,7 +532,10 @@ export function PitcherInput({
                   return (
                     <td
                       key={inning}
-                      className="px-1 py-1 text-center cursor-pointer hover:bg-blue-50 transition-colors rounded"
+                      className={cn(
+                        "px-1 py-1 text-center cursor-pointer hover:bg-blue-50 transition-colors rounded",
+                        inning === activeInning && "bg-amber-50"
+                      )}
                       onClick={() => handleInningCellClick(pIdx, inning)}
                     >
                       {val !== null ? (

--- a/components/score-input.tsx
+++ b/components/score-input.tsx
@@ -15,6 +15,8 @@ interface ScoreInputProps {
   hasX?: boolean
   xScore?: number | null
   onXChange?: (hasX: boolean, xScore: number | null) => void
+  activeInning?: number | null
+  onInningFocus?: (inning: number) => void
 }
 
 export function ScoreInput({
@@ -27,6 +29,8 @@ export function ScoreInput({
   hasX = false,
   xScore = null,
   onXChange,
+  activeInning,
+  onInningFocus,
 }: ScoreInputProps) {
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null)
   const isLongPressRef = useRef(false)
@@ -63,6 +67,7 @@ export function ScoreInput({
       isLongPressRef.current = false
       return
     }
+    onInningFocus?.(inning)
     const currentScore = inningScores[inning - 1]?.[team] || 0
     const newScore = currentScore >= 9 ? 0 : currentScore + 1
     updateScore(inning, team, newScore)
@@ -179,7 +184,10 @@ export function ScoreInput({
               {innings.map((inning) => (
                 <th
                   key={inning}
-                  className="w-10 min-w-[40px] px-1 py-2 text-center text-xs font-semibold"
+                  className={cn(
+                    "w-10 min-w-[40px] px-1 py-2 text-center text-xs font-semibold transition-colors",
+                    inning === activeInning ? "bg-amber-100 text-amber-800" : ""
+                  )}
                 >
                   {inning}
                 </th>
@@ -199,7 +207,7 @@ export function ScoreInput({
                 {isFirstBatting ? "自チーム" : "相手"}
               </td>
               {innings.map((inning) => (
-                <td key={inning} className="p-1">
+                <td key={inning} className={cn("p-1 transition-colors", inning === activeInning && "bg-amber-50")}>
                   <button
                     onClick={() => handleScoreClick(inning, isFirstBatting ? "our" : "opponent")}
                     onMouseDown={() => handleLongPressStart(inning, isFirstBatting ? "our" : "opponent")}
@@ -244,7 +252,7 @@ export function ScoreInput({
               {innings.map((inning) => {
                 const isLastInningX = hasX && inning === totalInnings
                 return (
-                  <td key={inning} className="p-1">
+                  <td key={inning} className={cn("p-1 transition-colors", inning === activeInning && "bg-amber-50")}>
                     {isLastInningX ? (
                       <div className="w-full h-10 flex items-center justify-center text-lg font-bold rounded-lg bg-amber-50 text-amber-700 select-none">
                         {xScore === null ? "✕" : `${xScore}✕`}


### PR DESCRIPTION
スコアセル・打席セル・投手イニングセルのクリックで activeInning を更新し、
スコアボード・打撃成績・投手成績（イニングごとモード）の該当列を amber 色でハイライトする。

https://claude.ai/code/session_01PXse4GdcK5hwNQ48REF5iV