### PR TITLE
feat: 試合入力画面に選手追加機能を実装（Combobox + 登録モーダル）

### DIFF
--- a/app/[teamId]/players/actions.ts
+++ b/app/[teamId]/players/actions.ts
@@ -2,11 +2,16 @@
 
 import { revalidatePath } from "next/cache"
 import { createClient } from "@/lib/supabase/server"
-import { requireTeamAdmin } from "@/lib/auth"
+import { requireTeamAdmin, getShareTokenSession } from "@/lib/auth"
 
-export async function addPlayer(teamId: string, name: string, number: string | null) {
-  const session = await requireTeamAdmin(teamId)
-  if (!session) throw new Error("管理者権限が必要です")
+export async function addPlayer(teamId: string, name: string, number: string | null, shareToken?: string) {
+  if (shareToken) {
+    const session = await getShareTokenSession(shareToken)
+    if (!session || session.teamId !== teamId) throw new Error("アクセスできません")
+  } else {
+    const session = await requireTeamAdmin(teamId)
+    if (!session) throw new Error("管理者権限が必要です")
+  }
 
   const supabase = await createClient()
   const { data, error } = await supabase

--- a/components/game-editor.tsx
+++ b/components/game-editor.tsx
@@ -74,6 +74,10 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack, player
   // 登録済み選手
   const [registeredPlayers, setRegisteredPlayers] = useState<Player[]>(initialPlayers ?? [])
 
+  const handlePlayerAdded = (player: Player) => {
+    setRegisteredPlayers((prev) => [...prev, player])
+  }
+
   // 投手成績
   const [pitchers, setPitchers] = useState<PitcherResult[]>([])
 
@@ -712,6 +716,10 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack, player
           totalInnings={totalInnings}
           activeInning={activeInning}
           onInningFocus={setActiveInning}
+          teamId={teamId}
+          onPlayerAdded={handlePlayerAdded}
+          isAdmin={isAdmin}
+          shareToken={shareToken}
         />
       </div>
 
@@ -731,6 +739,10 @@ export function GameEditor({ gameId, teamId, shareToken, isAdmin, onBack, player
         currentEntries={currentLineupSlot?.entries || []}
         onSave={handleLineupSave}
         registeredPlayers={registeredPlayers}
+        teamId={teamId}
+        onPlayerAdded={handlePlayerAdded}
+        isAdmin={isAdmin}
+        shareToken={shareToken}
       />
 
       {/* 共有URLダイアログ */}

--- a/components/pitcher-input.tsx
+++ b/components/pitcher-input.tsx
@@ -6,7 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { cn } from "@/lib/utils"
 import type { PitcherResult, PitcherInningStats, Player } from "@/lib/batting-types"
 import { Plus, Trash2, Trophy, ThumbsDown, Shield, Star, Minus } from "lucide-react"
-import { sortPlayersByNumber } from "@/lib/sort-utils"
+import { PlayerCombobox } from "@/components/player-combobox"
 
 interface PitcherInputProps {
   pitchers: PitcherResult[]
@@ -15,6 +15,10 @@ interface PitcherInputProps {
   totalInnings?: number
   activeInning?: number | null
   onInningFocus?: (inning: number) => void
+  teamId: string
+  onPlayerAdded: (player: Player) => void
+  isAdmin?: boolean
+  shareToken?: string
 }
 
 export function formatInnings(outs: number, isMidInningExit: boolean): string {
@@ -104,6 +108,10 @@ export function PitcherInput({
   totalInnings = 9,
   activeInning,
   onInningFocus,
+  teamId,
+  onPlayerAdded,
+  isAdmin = false,
+  shareToken,
 }: PitcherInputProps) {
   const [inputMode, setInputMode] = useState<InputMode>("inning")
   const [confirmDialog, setConfirmDialog] = useState<{ open: boolean; targetMode: InputMode }>({ open: false, targetMode: "aggregate" })
@@ -372,33 +380,21 @@ export function PitcherInput({
     <div>
       <label className="text-sm font-semibold text-slate-700 mb-2 block">選手名</label>
       {!form.isHelper && (
-        registeredPlayers.length > 0 ? (
-          <select
-            value={form.playerId}
-            onChange={(e) => {
-              const player = registeredPlayers.find(p => p.id === e.target.value)
-              if (player) {
-                setForm({ ...form, playerId: player.id, playerName: player.name, isHelper: false })
-              }
-            }}
-            className="w-full h-12 px-4 rounded-xl border border-slate-200 bg-slate-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white transition-all text-slate-800"
-          >
-            <option value="">選手を選択</option>
-            {sortPlayersByNumber(registeredPlayers).map((player) => (
-              <option key={player.id} value={player.id}>
-                {player.number ? `${player.number} ` : ""}{player.name}
-              </option>
-            ))}
-          </select>
-        ) : (
-          <input
-            type="text"
-            value={form.playerName}
-            onChange={(e) => setForm({ ...form, playerName: e.target.value })}
-            placeholder="選手名を入力"
-            className="w-full h-12 px-4 rounded-xl border border-slate-200 bg-slate-50 focus:border-blue-500 focus:ring-2 focus:ring-blue-100 focus:bg-white transition-all text-slate-800 placeholder:text-slate-400"
-          />
-        )
+        <PlayerCombobox
+          players={registeredPlayers}
+          value={form.playerId}
+          onChange={(player) => {
+            if (player) {
+              setForm({ ...form, playerId: player.id, playerName: player.name, isHelper: false })
+            } else {
+              setForm({ ...form, playerId: "", playerName: "", isHelper: false })
+            }
+          }}
+          teamId={teamId}
+          onPlayerAdded={onPlayerAdded}
+          isAdmin={isAdmin}
+          shareToken={shareToken}
+        />
       )}
       <button
         onClick={() => {

--- a/components/player-combobox.tsx
+++ b/components/player-combobox.tsx
@@ -3,7 +3,12 @@
 import { useState } from "react"
 import { Check, ChevronsUpDown, UserPlus } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import {
   Command,
   CommandEmpty,
@@ -12,8 +17,6 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import type { Player } from "@/lib/batting-types"
 import { sortPlayersByNumber } from "@/lib/sort-utils"
@@ -46,7 +49,7 @@ export function PlayerCombobox({
   placeholder = "選手を選択...",
   className,
 }: PlayerComboboxProps) {
-  const [open, setOpen] = useState(false)
+  const [searchOpen, setSearchOpen] = useState(false)
   const [searchValue, setSearchValue] = useState("")
   const [registerOpen, setRegisterOpen] = useState(false)
   const [newName, setNewName] = useState("")
@@ -68,7 +71,7 @@ export function PlayerCombobox({
       onPlayerAdded?.(player)
       onChange(player)
       setRegisterOpen(false)
-      setOpen(false)
+      setSearchOpen(false)
       setNewName("")
       setNewNumber("")
     } catch (e) {
@@ -80,33 +83,40 @@ export function PlayerCombobox({
 
   return (
     <>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            role="combobox"
-            aria-expanded={open}
-            className={cn(
-              "w-full h-12 px-4 flex items-center justify-between rounded-xl",
-              "bg-white border border-slate-200 text-base",
-              "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400",
-              className
-            )}
-          >
-            <span className={selectedPlayer ? "text-slate-800" : "text-slate-400"}>
-              {selectedPlayer ? formatPlayerLabel(selectedPlayer) : placeholder}
-            </span>
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-          </button>
-        </PopoverTrigger>
-        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+      {/* 選手選択トリガーボタン */}
+      <button
+        type="button"
+        onClick={() => {
+          setSearchValue("")
+          setSearchOpen(true)
+        }}
+        className={cn(
+          "w-full h-12 px-4 flex items-center justify-between rounded-xl",
+          "bg-white border border-slate-200 text-base",
+          "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400",
+          className
+        )}
+      >
+        <span className={selectedPlayer ? "text-slate-800" : "text-slate-400"}>
+          {selectedPlayer ? formatPlayerLabel(selectedPlayer) : placeholder}
+        </span>
+        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+      </button>
+
+      {/* 選手検索ダイアログ */}
+      <Dialog open={searchOpen} onOpenChange={setSearchOpen}>
+        <DialogContent className="max-w-sm p-0 gap-0">
+          <DialogHeader className="sr-only">
+            <DialogTitle>選手を選択</DialogTitle>
+          </DialogHeader>
           <Command>
             <CommandInput
               placeholder="名前で検索..."
               value={searchValue}
               onValueChange={setSearchValue}
+              className="h-14 text-base"
             />
-            <CommandList>
+            <CommandList className="max-h-[50vh] overflow-y-auto">
               <CommandEmpty>
                 {canAddPlayer ? (
                   <button
@@ -115,13 +125,13 @@ export function PlayerCombobox({
                       setNewName(searchValue)
                       setRegisterOpen(true)
                     }}
-                    className="w-full py-3 px-4 text-sm text-blue-600 hover:bg-blue-50 flex items-center gap-2"
+                    className="w-full py-4 px-4 text-sm text-blue-600 hover:bg-blue-50 flex items-center gap-2"
                   >
                     <UserPlus className="h-4 w-4 shrink-0" />
                     {searchValue ? `「${searchValue}」を登録` : "選手を登録"}
                   </button>
                 ) : (
-                  <p className="py-3 text-sm text-slate-400">一致する選手がいません</p>
+                  <p className="py-4 text-sm text-slate-400">一致する選手がいません</p>
                 )}
               </CommandEmpty>
               <CommandGroup>
@@ -129,14 +139,15 @@ export function PlayerCombobox({
                   <CommandItem
                     key={player.id}
                     value={player.name}
+                    className="py-3 text-base"
                     onSelect={() => {
                       onChange(player)
-                      setOpen(false)
+                      setSearchOpen(false)
                       setSearchValue("")
                     }}
                   >
                     <Check
-                      className={cn("mr-2 h-4 w-4", value === player.id ? "opacity-100" : "opacity-0")}
+                      className={cn("mr-2 h-4 w-4 shrink-0", value === player.id ? "opacity-100" : "opacity-0")}
                     />
                     {formatPlayerLabel(player)}
                   </CommandItem>
@@ -144,9 +155,10 @@ export function PlayerCombobox({
               </CommandGroup>
             </CommandList>
           </Command>
-        </PopoverContent>
-      </Popover>
+        </DialogContent>
+      </Dialog>
 
+      {/* 選手登録ダイアログ */}
       <Dialog open={registerOpen} onOpenChange={setRegisterOpen}>
         <DialogContent className="max-w-sm">
           <DialogHeader>
@@ -178,23 +190,24 @@ export function PlayerCombobox({
             {error && <p className="text-sm text-red-500">{error}</p>}
           </div>
           <div className="flex gap-3">
-            <Button
-              variant="outline"
-              className="flex-1"
+            <button
+              type="button"
               onClick={() => {
                 setRegisterOpen(false)
                 setError(null)
               }}
+              className="flex-1 h-12 rounded-xl font-semibold bg-slate-100 text-slate-600 hover:bg-slate-200 transition-all"
             >
               キャンセル
-            </Button>
-            <Button
-              className="flex-1"
+            </button>
+            <button
+              type="button"
               onClick={handleRegister}
               disabled={!newName.trim() || isSubmitting}
+              className="flex-1 h-12 rounded-xl font-semibold bg-blue-500 text-white hover:bg-blue-600 shadow-lg shadow-blue-500/25 transition-all disabled:opacity-50 disabled:pointer-events-none"
             >
               {isSubmitting ? "登録中..." : "登録"}
-            </Button>
+            </button>
           </div>
         </DialogContent>
       </Dialog>

--- a/components/player-combobox.tsx
+++ b/components/player-combobox.tsx
@@ -1,0 +1,203 @@
+"use client"
+
+import { useState } from "react"
+import { Check, ChevronsUpDown, UserPlus } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import type { Player } from "@/lib/batting-types"
+import { sortPlayersByNumber } from "@/lib/sort-utils"
+import { addPlayer } from "@/app/[teamId]/players/actions"
+
+interface PlayerComboboxProps {
+  players: Player[]
+  value: string
+  onChange: (player: Player | null) => void
+  teamId: string
+  onPlayerAdded?: (player: Player) => void
+  isAdmin?: boolean
+  shareToken?: string
+  placeholder?: string
+  className?: string
+}
+
+function formatPlayerLabel(player: Player): string {
+  return player.number ? `#${player.number} ${player.name}` : player.name
+}
+
+export function PlayerCombobox({
+  players,
+  value,
+  onChange,
+  teamId,
+  onPlayerAdded,
+  isAdmin = false,
+  shareToken,
+  placeholder = "選手を選択...",
+  className,
+}: PlayerComboboxProps) {
+  const [open, setOpen] = useState(false)
+  const [searchValue, setSearchValue] = useState("")
+  const [registerOpen, setRegisterOpen] = useState(false)
+  const [newName, setNewName] = useState("")
+  const [newNumber, setNewNumber] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const canAddPlayer = isAdmin || !!shareToken
+  const sortedPlayers = sortPlayersByNumber(players)
+  const selectedPlayer = players.find((p) => p.id === value) ?? null
+
+  const handleRegister = async () => {
+    if (!newName.trim()) return
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      const data = await addPlayer(teamId, newName.trim(), newNumber.trim() || null, shareToken)
+      const player: Player = { id: data.id, name: data.name, number: data.number }
+      onPlayerAdded?.(player)
+      onChange(player)
+      setRegisterOpen(false)
+      setOpen(false)
+      setNewName("")
+      setNewNumber("")
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "登録に失敗しました")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            role="combobox"
+            aria-expanded={open}
+            className={cn(
+              "w-full h-12 px-4 flex items-center justify-between rounded-xl",
+              "bg-white border border-slate-200 text-base",
+              "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400",
+              className
+            )}
+          >
+            <span className={selectedPlayer ? "text-slate-800" : "text-slate-400"}>
+              {selectedPlayer ? formatPlayerLabel(selectedPlayer) : placeholder}
+            </span>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+          <Command>
+            <CommandInput
+              placeholder="名前で検索..."
+              value={searchValue}
+              onValueChange={setSearchValue}
+            />
+            <CommandList>
+              <CommandEmpty>
+                {canAddPlayer ? (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setNewName(searchValue)
+                      setRegisterOpen(true)
+                    }}
+                    className="w-full py-3 px-4 text-sm text-blue-600 hover:bg-blue-50 flex items-center gap-2"
+                  >
+                    <UserPlus className="h-4 w-4 shrink-0" />
+                    {searchValue ? `「${searchValue}」を登録` : "選手を登録"}
+                  </button>
+                ) : (
+                  <p className="py-3 text-sm text-slate-400">一致する選手がいません</p>
+                )}
+              </CommandEmpty>
+              <CommandGroup>
+                {sortedPlayers.map((player) => (
+                  <CommandItem
+                    key={player.id}
+                    value={player.name}
+                    onSelect={() => {
+                      onChange(player)
+                      setOpen(false)
+                      setSearchValue("")
+                    }}
+                  >
+                    <Check
+                      className={cn("mr-2 h-4 w-4", value === player.id ? "opacity-100" : "opacity-0")}
+                    />
+                    {formatPlayerLabel(player)}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      <Dialog open={registerOpen} onOpenChange={setRegisterOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>選手を登録</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div>
+              <label className="text-sm font-semibold text-slate-700 mb-1 block">
+                選手名 <span className="text-red-500">*</span>
+              </label>
+              <Input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="選手名を入力"
+                className="h-11"
+                onKeyDown={(e) => e.key === "Enter" && handleRegister()}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-semibold text-slate-700 mb-1 block">背番号</label>
+              <Input
+                value={newNumber}
+                onChange={(e) => setNewNumber(e.target.value)}
+                placeholder="例: 10"
+                className="h-11"
+                onKeyDown={(e) => e.key === "Enter" && handleRegister()}
+              />
+            </div>
+            {error && <p className="text-sm text-red-500">{error}</p>}
+          </div>
+          <div className="flex gap-3">
+            <Button
+              variant="outline"
+              className="flex-1"
+              onClick={() => {
+                setRegisterOpen(false)
+                setError(null)
+              }}
+            >
+              キャンセル
+            </Button>
+            <Button
+              className="flex-1"
+              onClick={handleRegister}
+              disabled={!newName.trim() || isSubmitting}
+            >
+              {isSubmitting ? "登録中..." : "登録"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/components/player-select-dialog.tsx
+++ b/components/player-select-dialog.tsx
@@ -10,7 +10,7 @@ import {
 import { cn } from "@/lib/utils"
 import type { LineupEntry, FieldPosition, Player } from "@/lib/batting-types"
 import { FIELD_POSITIONS, SUBSTITUTE_ROLES } from "@/lib/batting-types"
-import { sortPlayersByNumber } from "@/lib/sort-utils"
+import { PlayerCombobox } from "@/components/player-combobox"
 
 interface PlayerSelectDialogProps {
   open: boolean
@@ -19,6 +19,10 @@ interface PlayerSelectDialogProps {
   currentEntries: LineupEntry[]
   registeredPlayers: Player[]
   onSave: (entries: LineupEntry[]) => void
+  teamId: string
+  onPlayerAdded: (player: Player) => void
+  isAdmin?: boolean
+  shareToken?: string
 }
 
 export function PlayerSelectDialog({
@@ -28,6 +32,10 @@ export function PlayerSelectDialog({
   currentEntries,
   registeredPlayers,
   onSave,
+  teamId,
+  onPlayerAdded,
+  isAdmin = false,
+  shareToken,
 }: PlayerSelectDialogProps) {
   const [entries, setEntries] = useState<LineupEntry[]>([])
 
@@ -41,8 +49,7 @@ export function PlayerSelectDialog({
     }
   }, [open, currentEntries])
 
-  const handlePlayerSelect = (index: number, playerId: string) => {
-    const player = registeredPlayers.find(p => p.id === playerId)
+  const handlePlayerSelect = (index: number, player: Player | null) => {
     setEntries((prev) => {
       const newEntries = [...prev]
       if (player) {
@@ -72,19 +79,6 @@ export function PlayerSelectDialog({
         playerId: "",
         playerName: "助っ人",
         isHelper: true,
-      }
-      return newEntries
-    })
-  }
-
-  const handleNameChange = (index: number, name: string) => {
-    setEntries((prev) => {
-      const newEntries = [...prev]
-      newEntries[index] = {
-        ...newEntries[index],
-        playerName: name,
-        playerId: "",
-        isHelper: false,
       }
       return newEntries
     })
@@ -167,55 +161,19 @@ export function PlayerSelectDialog({
                 <label className="block text-xs font-semibold text-slate-500 mb-2">
                   選手名
                 </label>
-                {registeredPlayers.length > 0 ? (
-                  <div className="space-y-2">
-                    <select
-                      value={entry.isHelper ? "" : entry.playerId}
-                      onChange={(e) => handlePlayerSelect(index, e.target.value)}
-                      className={cn(
-                        "w-full h-12 px-4 text-base rounded-xl",
-                        "bg-white border border-slate-200",
-                        "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
-                      )}
-                    >
-                      <option value="">選手を選択...</option>
-                      {sortPlayersByNumber(registeredPlayers).map((player) => (
-                        <option key={player.id} value={player.id}>
-                          {player.number ? `${player.number} ` : ""}{player.name}
-                        </option>
-                      ))}
-                    </select>
-                    {!entry.isHelper && !entry.playerId && (
-                      <input
-                        type="text"
-                        value={entry.playerName}
-                        onChange={(e) => handleNameChange(index, e.target.value)}
-                        placeholder="または名前を直接入力"
-                        className={cn(
-                          "w-full h-10 px-4 text-sm rounded-lg",
-                          "bg-white border border-slate-200",
-                          "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
-                        )}
-                      />
-                    )}
-                  </div>
-                ) : (
-                  !entry.isHelper && (
-                    <input
-                      type="text"
-                      value={entry.playerName}
-                      onChange={(e) => handleNameChange(index, e.target.value)}
-                      placeholder="名前を入力"
-                      className={cn(
-                        "w-full h-12 px-4 text-lg rounded-lg",
-                        "bg-white border border-slate-200",
-                        "focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
-                      )}
-                    />
-                  )
+                {!entry.isHelper && (
+                  <PlayerCombobox
+                    players={registeredPlayers}
+                    value={entry.playerId}
+                    onChange={(player) => handlePlayerSelect(index, player)}
+                    teamId={teamId}
+                    onPlayerAdded={onPlayerAdded}
+                    isAdmin={isAdmin}
+                    shareToken={shareToken}
+                  />
                 )}
                 <button
-                  onClick={() => entry.isHelper ? handlePlayerSelect(index, "") : handleHelperSelect(index)}
+                  onClick={() => entry.isHelper ? handlePlayerSelect(index, null) : handleHelperSelect(index)}
                   className={cn(
                     "mt-2 text-xs px-3 py-1.5 rounded-lg transition-all",
                     entry.isHelper

--- a/scripts/007_players_share_insert.sql
+++ b/scripts/007_players_share_insert.sql
@@ -4,7 +4,7 @@
 -- ============================================================
 
 -- team_id に有効な共有トークンが存在するか確認するヘルパー関数
-CREATE OR REPLACE FUNCTION public.team_has_valid_share_token(p_team_id UUID)
+CREATE OR REPLACE FUNCTION public.team_has_valid_share_token(p_team_id TEXT)
 RETURNS BOOLEAN
 LANGUAGE sql
 STABLE

--- a/scripts/007_players_share_insert.sql
+++ b/scripts/007_players_share_insert.sql
@@ -1,0 +1,31 @@
+-- ============================================================
+-- players テーブルへの共有トークン経由 INSERT を許可
+-- Supabase SQL Editorで実行してください
+-- ============================================================
+
+-- team_id に有効な共有トークンが存在するか確認するヘルパー関数
+CREATE OR REPLACE FUNCTION public.team_has_valid_share_token(p_team_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.game_share_tokens gst
+    JOIN public.games g ON g.id = gst.game_id
+    WHERE g.team_id = p_team_id
+      AND gst.expires_at > NOW()
+  );
+$$;
+
+-- players INSERT: 管理者 OR 有効な共有トークンがあるチームへ許可
+DROP POLICY IF EXISTS "players_insert_policy" ON public.players;
+CREATE POLICY "players_insert_policy" ON public.players
+  FOR INSERT WITH CHECK (
+    team_id IN (
+      SELECT id FROM public.teams WHERE user_id = auth.uid()
+    )
+    OR team_has_valid_share_token(team_id)
+  );


### PR DESCRIPTION
- PlayerCombobox コンポーネントを新規作成（Command + Popover による shadcn/ui コンボボックス）
  - 表示形式: `#背番号 名前`、名前で検索
  - 検索にヒットしない場合に「選手を登録」ボタンを表示
  - 登録モーダルから選手名・背番号を入力して即時登録
  - 管理者と共有URL利用者の両方で登録ボタンを表示（isAdmin || shareToken）
- PlayerSelectDialog: `<select>` と「または名前を入力」を PlayerCombobox に置換
- PitcherInput: `<select>` を PlayerCombobox に置換
- GameEditor: teamId / isAdmin / shareToken / onPlayerAdded を各コンポーネントに伝播
- addPlayer server action: shareToken 引数を追加し管理者 OR 共有トークンで認可
- scripts/007_players_share_insert.sql: team_has_valid_share_token 関数と
  players INSERT ポリシーの更新（共有トークン経由の INSERT を許可）

Closes #94

https://claude.ai/code/session_01JfaWfZeC7djgC5aU2EuXH8