### PR TITLE
fix: 共有URLからの対戦相手・球場編集が保存されない不具合を修正

### DIFF
--- a/scripts/008_fix_games_update_rls.sql
+++ b/scripts/008_fix_games_update_rls.sql
@@ -1,0 +1,18 @@
+-- ============================================================
+-- games テーブルの UPDATE ポリシーを修正
+-- 共有トークン経由でも対戦相手・球場等を更新できるようにする
+-- ============================================================
+-- 問題: games テーブルの UPDATE ポリシーには他テーブルと異なり
+--       game_has_valid_share_token() による共有トークン例外がなかった。
+--       そのため共有URLからの保存が RLS に阻まれ、0行更新（エラーなし）
+--       となり、APIが誤って success: true を返していた。
+-- ============================================================
+
+DROP POLICY IF EXISTS "games_update_policy" ON public.games;
+CREATE POLICY "games_update_policy" ON public.games
+  FOR UPDATE USING (
+    team_id IN (
+      SELECT id FROM public.teams WHERE user_id = auth.uid()
+    )
+    OR game_has_valid_share_token(id)
+  );


### PR DESCRIPTION
## 概要

共有URLからアクセスした編集画面で対戦相手・球場を変更すると「保存しました」と表示されるが、試合結果画面に反映されない不具合を修正する。

## 原因

`games` テーブルの UPDATE RLS ポリシーに、共有トークン経由のアクセスを許可する条件が欠落していた。

```sql
-- 修正前（共有トークンユーザーは更新不可）
CREATE POLICY "games_update_policy" ON public.games
  FOR UPDATE USING (
    team_id IN (SELECT id FROM public.teams WHERE user_id = auth.uid())
  );

-- 修正後
CREATE POLICY "games_update_policy" ON public.games
  FOR UPDATE USING (
    team_id IN (SELECT id FROM public.teams WHERE user_id = auth.uid())
    OR game_has_valid_share_token(id)  -- 追加
  );
```

### 故障の連鎖

1. 共有トークンユーザーは Supabase Auth セッションを持たない（`auth.uid() = null`）
2. API の `requireGameAccess` はサーバー側でトークン検証を通過
3. 実際の UPDATE は RLS に阻まれ、0行更新（エラーなし）
4. Supabase は0行更新でもエラーを返さないため、API が `{ success: true }` を返す
5. フロントエンドが「保存しました」を表示するが、DB には保存されていない

### プレビュー環境で再現しない理由

プレビュー環境では自動ログインが設定されており `auth.uid()` が null にならないため、RLS チェックが通ってしまい再現しなかった。

## 変更内容

- `scripts/008_fix_games_update_rls.sql` を追加
  - `games_update_policy` に `OR game_has_valid_share_token(id)` を追加
  - `inning_scores` / `lineup_entries` / `batting_results` など他テーブルと同じパターンに統一

## 適用方法

Supabase SQL Editor で `scripts/008_fix_games_update_rls.sql` を実行する。

## テスト

- [ ] 共有URLから対戦相手・球場を編集して保存後、試合結果画面に反映されることを確認
- [ ] 管理者ログイン状態での編集が引き続き動作することを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01K52NhGMcTwSJUcWraUVoD9)_