### PR TITLE
feat: 削除処理に確認ダイアログを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,15 @@
 
 ---
 
+## 削除処理のガイドライン
+
+- 削除操作には必ず `ConfirmDeleteDialog` コンポーネントで確認を挟む
+- `confirm()` や `alert()` などのブラウザネイティブダイアログは使用しない
+- コンポーネント: `components/confirm-delete-dialog.tsx`
+  - props: `open`, `onOpenChange`, `title`, `description`, `onConfirm`, `isPending?`
+
+---
+
 ## 禁止事項
 
 - README・ドキュメントを確認なしに生成・変更しない

--- a/app/[teamId]/games/[id]/delete-button.tsx
+++ b/app/[teamId]/games/[id]/delete-button.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useTransition } from "react"
+import { useState, useTransition } from "react"
 import { Loader2, Trash2 } from "lucide-react"
 import { deleteGame } from "./actions"
+import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog"
 
 interface DeleteButtonProps {
   gameId: string
@@ -11,22 +12,33 @@ interface DeleteButtonProps {
 
 export function DeleteButton({ gameId, teamId }: DeleteButtonProps) {
   const [isPending, startTransition] = useTransition()
+  const [open, setOpen] = useState(false)
 
-  const handleDelete = () => {
-    if (!confirm("この試合を削除しますか？")) return
+  const handleConfirm = () => {
+    setOpen(false)
     startTransition(async () => {
       await deleteGame(teamId, gameId)
     })
   }
 
   return (
-    <button
-      onClick={handleDelete}
-      disabled={isPending}
-      className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-bold text-white shadow-md transition-all hover:bg-red-700 disabled:opacity-50"
-    >
-      {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
-      削除
-    </button>
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        disabled={isPending}
+        className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-bold text-white shadow-md transition-all hover:bg-red-700 disabled:opacity-50"
+      >
+        {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+        削除
+      </button>
+      <ConfirmDeleteDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="試合を削除しますか？"
+        description="この操作は取り消せません。試合に関連するすべてのデータが削除されます。"
+        onConfirm={handleConfirm}
+        isPending={isPending}
+      />
+    </>
   )
 }

--- a/app/[teamId]/players/players-client.tsx
+++ b/app/[teamId]/players/players-client.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { PlusCircle, Users, Loader2, X, Pencil, Trash2, Check } from "lucide-react"
 import { sortPlayersByNumber } from "@/lib/sort-utils"
 import { addPlayer, updatePlayer, deletePlayer } from "./actions"
+import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog"
 
 interface Player {
   id: string
@@ -26,6 +27,7 @@ export function PlayersClient({ initialPlayers, isAdmin, teamId }: PlayersClient
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editName, setEditName] = useState("")
   const [editNumber, setEditNumber] = useState("")
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null)
 
   const handleAdd = async () => {
     if (!newName.trim()) {
@@ -66,8 +68,14 @@ export function PlayersClient({ initialPlayers, isAdmin, teamId }: PlayersClient
     }
   }
 
-  const handleDelete = async (id: string) => {
-    if (!confirm("この選手を削除しますか？")) return
+  const handleDelete = (id: string) => {
+    setDeleteTargetId(id)
+  }
+
+  const handleConfirmDelete = async () => {
+    if (!deleteTargetId) return
+    const id = deleteTargetId
+    setDeleteTargetId(null)
     try {
       await deletePlayer(teamId, id)
       setPlayers((prev) => prev.filter((p) => p.id !== id))
@@ -185,6 +193,13 @@ export function PlayersClient({ initialPlayers, isAdmin, teamId }: PlayersClient
           </div>
         )}
       </div>
+      <ConfirmDeleteDialog
+        open={deleteTargetId !== null}
+        onOpenChange={(open) => { if (!open) setDeleteTargetId(null) }}
+        title="選手を削除しますか？"
+        description="この操作は取り消せません。選手に関連するすべてのデータが削除されます。"
+        onConfirm={handleConfirmDelete}
+      />
     </main>
   )
 }

--- a/components/batting-input-dialog.tsx
+++ b/components/batting-input-dialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
+import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog"
 import { cn } from "@/lib/utils"
 import type { BattingResult, HitResult, HitDirection, CellPosition, RunnerState, StolenBase } from "@/lib/batting-types"
 
@@ -63,6 +64,7 @@ export function BattingInputDialog({
   const [scored, setScored] = useState<boolean>(false)
   const [runners, setRunners] = useState<RunnerState>({ first: false, second: false, third: false })
   const [stolenBases, setStolenBases] = useState<StolenBase>({ second: false, third: false, home: false })
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
 
   useEffect(() => {
     if (existingResult) {
@@ -471,13 +473,22 @@ export function BattingInputDialog({
         {/* 固定フッター - アクションボタン */}
         <div className="sticky bottom-0 z-20 flex gap-3 p-4 bg-white border-t border-slate-200 flex-shrink-0">
           {existingResult && (
-            <Button
-              variant="destructive"
-              onClick={onDelete}
-              className="flex-1 h-12 text-base font-bold rounded-xl"
-            >
-              削除
-            </Button>
+            <>
+              <Button
+                variant="destructive"
+                onClick={() => setDeleteConfirmOpen(true)}
+                className="flex-1 h-12 text-base font-bold rounded-xl"
+              >
+                削除
+              </Button>
+              <ConfirmDeleteDialog
+                open={deleteConfirmOpen}
+                onOpenChange={setDeleteConfirmOpen}
+                title="打席結果を削除しますか？"
+                description="この打席の記録が削除されます。"
+                onConfirm={() => { setDeleteConfirmOpen(false); onDelete() }}
+              />
+            </>
           )}
           <Button
             variant="outline"

--- a/components/confirm-delete-dialog.tsx
+++ b/components/confirm-delete-dialog.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { buttonVariants } from "@/components/ui/button"
+
+interface ConfirmDeleteDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description: string
+  onConfirm: () => void
+  isPending?: boolean
+}
+
+export function ConfirmDeleteDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onConfirm,
+  isPending,
+}: ConfirmDeleteDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="max-w-sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            className={buttonVariants({ variant: "destructive" })}
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            削除
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/pitcher-input.tsx
+++ b/components/pitcher-input.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils"
 import type { PitcherResult, PitcherInningStats, Player } from "@/lib/batting-types"
 import { Plus, Trash2, Trophy, ThumbsDown, Shield, Star, Minus, HelpCircle } from "lucide-react"
 import { PlayerCombobox } from "@/components/player-combobox"
+import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog"
 
 interface PitcherInputProps {
   pitchers: PitcherResult[]
@@ -144,6 +145,11 @@ export function PitcherInput({
   const [inningDialogInning, setInningDialogInning] = useState<number>(1)
   const [inningForm, setInningForm] = useState<PitcherInningStats>(EMPTY_INNING_STATS)
 
+  // 削除確認ダイアログ
+  const [aggDeleteTarget, setAggDeleteTarget] = useState<number | null>(null)
+  const [inningDeleteTarget, setInningDeleteTarget] = useState<number | null>(null)
+  const [inningStatsDeleteOpen, setInningStatsDeleteOpen] = useState(false)
+
   const handleModeToggle = (newMode: InputMode) => {
     if (newMode === inputMode) return
 
@@ -222,7 +228,13 @@ export function PitcherInput({
   }
 
   const handleAggDelete = (index: number) => {
-    onPitchersChange(pitchers.filter((_, i) => i !== index))
+    setAggDeleteTarget(index)
+  }
+
+  const handleAggDeleteConfirm = () => {
+    if (aggDeleteTarget === null) return
+    onPitchersChange(pitchers.filter((_, i) => i !== aggDeleteTarget))
+    setAggDeleteTarget(null)
   }
 
   const handleAggSave = () => {
@@ -251,7 +263,13 @@ export function PitcherInput({
   }
 
   const handleInningDeletePitcher = (index: number) => {
-    onPitchersChange(pitchers.filter((_, i) => i !== index))
+    setInningDeleteTarget(index)
+  }
+
+  const handleInningDeleteConfirm = () => {
+    if (inningDeleteTarget === null) return
+    onPitchersChange(pitchers.filter((_, i) => i !== inningDeleteTarget))
+    setInningDeleteTarget(null)
   }
 
   const handlePlayerSave = () => {
@@ -298,6 +316,10 @@ export function PitcherInput({
   }
 
   const handleInningStatsDelete = () => {
+    setInningStatsDeleteOpen(true)
+  }
+
+  const handleInningStatsDeleteConfirm = () => {
     const updated = [...pitchers]
     const pitcher = { ...updated[inningDialogPitcherIndex] }
     const stats = (pitcher.inningStats ?? []).filter(s => s.inning !== inningDialogInning)
@@ -307,6 +329,7 @@ export function PitcherInput({
     pitcher.isMidInningExit = agg.isMidInningExit
     updated[inningDialogPitcherIndex] = pitcher
     onPitchersChange(updated)
+    setInningStatsDeleteOpen(false)
     setIsInningDialogOpen(false)
   }
 
@@ -841,6 +864,28 @@ export function PitcherInput({
           </div>
         </DialogContent>
       </Dialog>
+
+      <ConfirmDeleteDialog
+        open={aggDeleteTarget !== null}
+        onOpenChange={(open) => { if (!open) setAggDeleteTarget(null) }}
+        title="投手を削除しますか？"
+        description="この投手の記録が削除されます。"
+        onConfirm={handleAggDeleteConfirm}
+      />
+      <ConfirmDeleteDialog
+        open={inningDeleteTarget !== null}
+        onOpenChange={(open) => { if (!open) setInningDeleteTarget(null) }}
+        title="投手を削除しますか？"
+        description="この投手の記録が削除されます。"
+        onConfirm={handleInningDeleteConfirm}
+      />
+      <ConfirmDeleteDialog
+        open={inningStatsDeleteOpen}
+        onOpenChange={setInningStatsDeleteOpen}
+        title="イニングのデータを削除しますか？"
+        description="このイニングの成績が削除されます。"
+        onConfirm={handleInningStatsDeleteConfirm}
+      />
     </div>
   )
 }


### PR DESCRIPTION
全削除処理でブラウザの confirm() を廃止し、
shadcn/ui の AlertDialog を使った ConfirmDeleteDialog
コンポーネントに統一。
対象: 試合削除、選手削除、打席結果削除、投手削除（集計・イニングモード）、イニング成績削除。
CLAUDE.md に今後の削除処理に関するガイドラインを追記。

Closes #102
https://claude.ai/code/session_0117hKZoEPBt3cp51bsBvdg1