### PR TITLE
feat: タッチ時の即時フィードバックを追加

### DIFF
--- a/app/[teamId]/games/page.tsx
+++ b/app/[teamId]/games/page.tsx
@@ -70,7 +70,7 @@ export default async function GamesListPage({ params }: Props) {
                 <Link
                   key={game.id}
                   href={`/${teamId}/games/${game.id}`}
-                  className="block rounded-xl bg-white p-4 shadow-md transition-all hover:shadow-lg"
+                  className="block rounded-xl bg-white p-4 shadow-md transition-all hover:shadow-lg active:scale-[0.98] active:opacity-80"
                 >
                   <div className="flex items-center justify-between">
                     <div>

--- a/app/[teamId]/page.tsx
+++ b/app/[teamId]/page.tsx
@@ -70,7 +70,7 @@ export default async function TeamDashboardPage({ params }: Props) {
           {/* 試合一覧 */}
           <Link
             href={`/${teamId}/games`}
-            className="group rounded-2xl bg-white p-6 shadow-md transition-all hover:shadow-lg"
+            className="group rounded-2xl bg-white p-6 shadow-md transition-all hover:shadow-lg active:scale-[0.98] active:opacity-80"
           >
             <div className="flex items-start gap-4">
               <div className="rounded-xl bg-emerald-100 p-3">
@@ -93,7 +93,7 @@ export default async function TeamDashboardPage({ params }: Props) {
           {/* 個人成績 */}
           <Link
             href={`/${teamId}/stats`}
-            className="group rounded-2xl bg-white p-6 shadow-md transition-all hover:shadow-lg"
+            className="group rounded-2xl bg-white p-6 shadow-md transition-all hover:shadow-lg active:scale-[0.98] active:opacity-80"
           >
             <div className="flex items-start gap-4">
               <div className="rounded-xl bg-amber-100 p-3">
@@ -116,7 +116,7 @@ export default async function TeamDashboardPage({ params }: Props) {
           {/* 選手一覧 */}
           <Link
             href={`/${teamId}/players`}
-            className="group rounded-2xl bg-white p-6 shadow-md transition-all hover:shadow-lg"
+            className="group rounded-2xl bg-white p-6 shadow-md transition-all hover:shadow-lg active:scale-[0.98] active:opacity-80"
           >
             <div className="flex items-start gap-4">
               <div className="rounded-xl bg-purple-100 p-3">
@@ -163,7 +163,7 @@ export default async function TeamDashboardPage({ params }: Props) {
                     <Link
                       key={game.id}
                       href={`/${teamId}/games/${game.id}`}
-                      className="flex items-center justify-between rounded-lg border border-slate-100 p-3 transition-all hover:bg-slate-50"
+                      className="flex items-center justify-between rounded-lg border border-slate-100 p-3 transition-all hover:bg-slate-50 active:opacity-80 active:bg-slate-50"
                     >
                       <div>
                         <p className="text-sm text-slate-500">{game.date}</p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,10 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+* {
+  -webkit-tap-highlight-color: transparent;
+}
+
 @custom-variant dark (&:is(.dark *));
 
 :root {

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,15 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+@layer base {
+  button:not(:disabled):active {
+    opacity: 0.75;
+  }
+  a:active {
+    opacity: 0.8;
+  }
+}
+
 @custom-variant dark (&:is(.dark *));
 
 :root {

--- a/components/batting-input-dialog.tsx
+++ b/components/batting-input-dialog.tsx
@@ -393,7 +393,7 @@ export function BattingInputDialog({
                       key={result.value}
                       onClick={() => handleHitResultClick(result.value)}
                       className={cn(
-                        "px-4 py-2.5 rounded-xl font-bold text-sm transition-all duration-200",
+                        "px-4 py-2.5 rounded-xl font-bold text-sm transition-all duration-200 active:opacity-75",
                         getCategoryColor(result.category),
                         getSelectedStyle(result)
                       )}
@@ -415,7 +415,7 @@ export function BattingInputDialog({
                   key={n}
                   onClick={() => setRbiCount(n)}
                   className={cn(
-                    "flex-1 h-12 rounded-xl font-bold text-lg transition-all duration-200",
+                    "flex-1 h-12 rounded-xl font-bold text-lg transition-all duration-200 active:opacity-75",
                     rbiCount === n
                       ? "bg-slate-800 text-white shadow-lg scale-105"
                       : "bg-white border-2 border-slate-200 text-slate-600 hover:border-slate-400"
@@ -433,7 +433,7 @@ export function BattingInputDialog({
             <button
               onClick={() => setScored(prev => !prev)}
               className={cn(
-                "h-12 px-6 rounded-xl font-bold text-sm transition-all duration-200",
+                "h-12 px-6 rounded-xl font-bold text-sm transition-all duration-200 active:opacity-75",
                 scored
                   ? "bg-rose-500 text-white shadow-lg scale-105"
                   : "bg-white border-2 border-slate-200 text-slate-600 hover:border-rose-400"
@@ -456,7 +456,7 @@ export function BattingInputDialog({
                   key={key}
                   onClick={() => toggleStolenBase(key)}
                   className={cn(
-                    "flex-1 h-12 rounded-xl font-bold text-sm transition-all duration-200",
+                    "flex-1 h-12 rounded-xl font-bold text-sm transition-all duration-200 active:opacity-75",
                     stolenBases[key]
                       ? "bg-orange-500 text-white shadow-lg scale-105"
                       : "bg-white border-2 border-slate-200 text-slate-600 hover:border-orange-400"

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all active:scale-[0.97] active:opacity-80 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {


### PR DESCRIPTION
- Button コンポーネントに active:scale-[0.97] active:opacity-80 を追加し、全ボタンでタップ時に縮小・暗転するようにした
- globals.css で -webkit-tap-highlight-color: transparent を設定し、モバイルのデフォルトタップハイライトを除去
- batting-input-dialog のネイティブ button（打撃結果・打点・得点・盗塁）に active:opacity-75 を追加

https://claude.ai/code/session_01N8scCQVksbqTVzy4Z8mbiB